### PR TITLE
Include name of binary into default BISECT_FILE name.

### DIFF
--- a/src/library/runtime.ml
+++ b/src/library/runtime.ml
@@ -57,8 +57,14 @@ let init_with_array fn arr =
   if not (Hashtbl.mem table fn) then
     Hashtbl.add table fn arr
 
+
+
 let file_channel () =
-  let base_name = full_path (env_to_fname "BISECT_FILE" "bisect") in
+  let this    = match Array.length Sys.argv with
+                | 0 -> Filename.basename Sys.executable_name 
+                | _ -> Filename.basename Sys.argv.(0) in
+  let default = Printf.sprintf "bisect-%s" this in
+  let base_name = full_path (env_to_fname "BISECT_FILE" default) in
   let suffix = ref 0 in
   let next_name () =
     incr suffix;


### PR DESCRIPTION
By including the name of the binary running, logs for multiple binaries
can go to the same directory without having to use the env variable.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>