### PR TITLE
Install .mli files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,6 +156,10 @@ REPORTER_BYTE := $(INSTALL_SOURCE_DIR)/src/report/report.byte
 REPORTER_NATIVE := $(INSTALL_SOURCE_DIR)/src/report/report.native
 
 LIBRARY_FILES = $(foreach extension,a o cma cmi cmo cmx cmxa,$1.$(extension))
+INTERFACE_FILES = \
+	src/ocamlbuild/bisect_ppx_plugin.mli \
+	$(shell find src/library -name '*.mli') \
+	$(shell find $1/src -name '*.cmt*')
 
 install: FORCE
 	[ $(DEV_INSTALL) = "" ] || mkdir -p $(DEV_INSTALL_DIR)
@@ -169,6 +173,7 @@ install: FORCE
 		$(REWRITER) $(REPORTER) \
 		$(call LIBRARY_FILES,$(INSTALL_SOURCE_DIR)/src/$(RUNTIME)) \
 		$(call LIBRARY_FILES,\
-			$(INSTALL_SOURCE_DIR)/src/ocamlbuild/bisect_ppx_plugin)
+			$(INSTALL_SOURCE_DIR)/src/ocamlbuild/bisect_ppx_plugin) \
+		$(call INTERFACE_FILES,$(INSTALL_SOURCE_DIR))
 
 FORCE:

--- a/_tags
+++ b/_tags
@@ -29,6 +29,7 @@ true: -traverse, warn(A-4), warn_error(A-3)
 <src/syntax/bisect_ppx.{byte,native}>: use_str, package(ppx_tools)
 <src/report/report.{byte,native}>: use_str
 <src/ocamlbuild/*>: package(ocamlbuild)
+<src/ocamlbuild/*>: bin_annot
 
 # Self-instrumentation for testing and showing off
 <src/*/*/**>: instrument


### PR DESCRIPTION
```diff
 bisect_ppx_plugin.cma
 bisect_ppx_plugin.cmi
 bisect_ppx_plugin.cmo
+bisect_ppx_plugin.cmt
+bisect_ppx_plugin.cmti
 bisect_ppx_plugin.cmx
 bisect_ppx_plugin.cmxa
+bisect_ppx_plugin.mli
 bisect_ppx_plugin.o
+common.mli
+extension.mli
 opam.config
+runtime.mli
+version.mli
```

Is this too many/not enough of the `.mli` files?

Also installing the `.cmt`/`.cmti` files for the Ocamlbuild plugin, so it works nicely in `ocp-browser`. However, I wasn't able to get `ocp-browser` to work with the `.cmti?` files for the rest of the library. I am not sure if it's some kind of conflict with `-for-pack`. I tried installing all the submodules' `.cmti?` files and `bisect.cmt` for the pack.

cc @lindig
Resolves #98.