### PR TITLE
Eliminate .cmp files

### DIFF
--- a/src/library/common.mli
+++ b/src/library/common.mli
@@ -66,36 +66,32 @@ exception Modified_file of string
     instrumentation. The parameter is the name of the incriminated
     file. *)
 
-val cmp_file_of_ml_file : string -> string
-(** [cmp_file_of_ml_file f] returns the name of the {i cmp} file
-    associated with the {i ml} file named [f]. *)
-
-val write_runtime_data : out_channel -> (string * (int array)) list -> unit
+val write_runtime_data :
+  out_channel -> (string * (int array * string)) list -> unit
 (** [write_runtime_data oc d] writes the runtime data [d] to the output
     channel [oc] using the Bisect file format. The runtime data list [d]
     encodes a map (through an association list) from files to arrays of
     integers (the value at index {i i} being the number of times point
-    {i i} has been visited).
+    {i i} has been visited). The arrays are paired with point definition
+    lists, giving the location of each point in the file.
 
     Raises [Sys_error] if an i/o error occurs. *)
 
-val write_points : out_channel -> point_definition list -> string -> unit
-(** [write_points oc pts f] writes the point definitions [pts] to the
-    output channel [oc] using the Bisect file format. [f] is the name of
-    the source file related to point definitions, whose digest is written
-    to the output channel.
+val write_points : point_definition list -> string
+(** [write_points pts] converts the point definitions [pts] to a string. The
+    string is a binary byte sequence; it is not meant to be legible. *)
 
-    Raises [Sys_error] if an i/o error occurs. *)
-
-val read_runtime_data : string ->  (string * (int array)) list
+val read_runtime_data' : string -> (string * (int array * string)) list
 (** [read_runtime_data f] reads the runtime data from file [f].
 
     Raises [Sys_error] if an i/o error occurs. May also raise
     [Invalid_file], [Unsupported_version], or [Modified_file]. *)
 
-val read_points : string -> point_definition list
-(** [read_points f] reads the point definitions associated with the source
-    file named [f].
+val read_points' : string -> point_definition list
+(** [read_points s] reads point definitions from the string [s]. *)
 
-    Raises [Sys_error] if an i/o error occurs. May also raise
-    [Invalid_file], [Unsupported_version], or [Modified_file]. *)
+val read_runtime_data : string -> (string * int array) list
+  [@@ocaml.deprecated "read_runtime_data' will take the place of this function"]
+
+val read_points : string -> point_definition list
+  [@@ocaml.deprecated "read_points' will take the place of this function"]

--- a/src/library/runtime.ml
+++ b/src/library/runtime.ml
@@ -51,11 +51,11 @@ let verbose =
       fun msg ->
         Printf.fprintf (Lazy.force oc_l) "%s\n" (string_of_message msg)
 
-let table : (string, (int array)) Hashtbl.t = Hashtbl.create 17
+let table : (string, int array * string) Hashtbl.t = Hashtbl.create 17
 
-let init_with_array fn arr =
+let init_with_array fn arr points =
   if not (Hashtbl.mem table fn) then
-    Hashtbl.add table fn arr
+    Hashtbl.add table fn (arr, points)
 
 let file_channel () =
   let base_name = full_path (env_to_fname "BISECT_FILE" "bisect") in

--- a/src/library/runtime.mli
+++ b/src/library/runtime.mli
@@ -50,7 +50,9 @@
     should be specified with absolute paths. *)
 
 
-val init_with_array : string -> int array -> unit
-(** [init_with_array file marks] indicates that the file [file] is part of the
-    application that has been instrumented, using the passed array [marks] to
-    store marks. *)
+val init_with_array : string -> int array -> string -> unit
+(** [init_with_array file marks points] indicates that the file [file] is part
+    of the application that has been instrumented, using the passed array
+    [marks] to store visitation counts. [points] is a serialized
+    [Common.point_definition list] giving the locations of all points in the
+    file. *)

--- a/src/report/report.ml
+++ b/src/report/report.ml
@@ -65,7 +65,7 @@ let main () =
       fail () in
   let search_in_path = search_file !ReportArgs.search_path in
   let generic_output file conv =
-    ReportGeneric.output verbose file conv search_in_path data points in
+    ReportGeneric.output verbose file conv data points in
   let write_output = function
     | ReportArgs.Html_output dir ->
         mkdirs dir;

--- a/src/report/reportGeneric.ml
+++ b/src/report/reportGeneric.ml
@@ -27,14 +27,8 @@ class type converter =
     method point : int -> int -> string
   end
 
-let output_file verbose in_file conv resolver visited points =
+let output_file verbose in_file conv visited points =
   verbose (Printf.sprintf "Processing file '%s'..." in_file);
-  let resolved_in_file = resolver in_file in
-  match resolved_in_file with
-  | None ->
-    verbose "... file not found";
-    None
-  | Some _ ->
     let cmp_content = Hashtbl.find points in_file |> Common.read_points' in
     verbose (Printf.sprintf "... file has the following points: %s"
       (String.concat ","
@@ -64,10 +58,10 @@ let output_file verbose in_file conv resolver visited points =
     Buffer.add_string buffer (conv#file_footer in_file);
     Some (Buffer.contents buffer, stats)
 
-let output verbose file conv resolver data points =
+let output verbose file conv data points =
   let files, stats = Hashtbl.fold
       (fun file visited (files, summary) ->
-        match output_file verbose file conv resolver visited points with
+        match output_file verbose file conv visited points with
         | None -> files, summary
         | Some (text, stats) ->
           ((file, text) :: files, (ReportStat.add summary stats)))

--- a/src/report/reportGeneric.ml
+++ b/src/report/reportGeneric.ml
@@ -27,15 +27,15 @@ class type converter =
     method point : int -> int -> string
   end
 
-let output_file verbose in_file conv resolver visited =
+let output_file verbose in_file conv resolver visited points =
   verbose (Printf.sprintf "Processing file '%s'..." in_file);
   let resolved_in_file = resolver in_file in
   match resolved_in_file with
   | None ->
     verbose "... file not found";
     None
-  | Some resolved_in_file ->
-    let cmp_content = Common.read_points resolved_in_file in
+  | Some _ ->
+    let cmp_content = Hashtbl.find points in_file |> Common.read_points' in
     verbose (Printf.sprintf "... file has the following points: %s"
       (String.concat ","
         (List.map (fun pd ->
@@ -64,10 +64,10 @@ let output_file verbose in_file conv resolver visited =
     Buffer.add_string buffer (conv#file_footer in_file);
     Some (Buffer.contents buffer, stats)
 
-let output verbose file conv resolver data =
+let output verbose file conv resolver data points =
   let files, stats = Hashtbl.fold
       (fun file visited (files, summary) ->
-        match output_file verbose file conv resolver visited with
+        match output_file verbose file conv resolver visited points with
         | None -> files, summary
         | Some (text, stats) ->
           ((file, text) :: files, (ReportStat.add summary stats)))

--- a/src/report/reportGeneric.ml
+++ b/src/report/reportGeneric.ml
@@ -29,34 +29,34 @@ class type converter =
 
 let output_file verbose in_file conv visited points =
   verbose (Printf.sprintf "Processing file '%s'..." in_file);
-    let cmp_content = Hashtbl.find points in_file |> Common.read_points' in
-    verbose (Printf.sprintf "... file has the following points: %s"
-      (String.concat ","
-        (List.map (fun pd ->
-          Printf.sprintf "[%d %d]\n" pd.Common.offset pd.Common.identifier)
-          cmp_content)));
-    let len = Array.length visited in
-    let stats = ReportStat.make () in
-    let points =
-      List.map
-        (fun p ->
-          let nb =
-            if p.Common.identifier < len then
-              visited.(p.Common.identifier)
-            else
-              0 in
-          ReportStat.update stats (nb > 0);
-          (p.Common.offset, nb))
-        cmp_content in
-    let buffer = Buffer.create 64 in
-    Buffer.add_string buffer (conv#file_header in_file);
-    Buffer.add_string buffer (conv#file_summary stats);
-    List.iter
-      (fun (ofs, nb) ->
-        Buffer.add_string buffer (conv#point ofs nb))
-      points;
-    Buffer.add_string buffer (conv#file_footer in_file);
-    Some (Buffer.contents buffer, stats)
+  let cmp_content = Hashtbl.find points in_file |> Common.read_points' in
+  verbose (Printf.sprintf "... file has the following points: %s"
+    (String.concat ","
+      (List.map (fun pd ->
+        Printf.sprintf "[%d %d]\n" pd.Common.offset pd.Common.identifier)
+        cmp_content)));
+  let len = Array.length visited in
+  let stats = ReportStat.make () in
+  let points =
+    List.map
+      (fun p ->
+        let nb =
+          if p.Common.identifier < len then
+            visited.(p.Common.identifier)
+          else
+            0 in
+        ReportStat.update stats (nb > 0);
+        (p.Common.offset, nb))
+      cmp_content in
+  let buffer = Buffer.create 64 in
+  Buffer.add_string buffer (conv#file_header in_file);
+  Buffer.add_string buffer (conv#file_summary stats);
+  List.iter
+    (fun (ofs, nb) ->
+      Buffer.add_string buffer (conv#point ofs nb))
+    points;
+  Buffer.add_string buffer (conv#file_footer in_file);
+  Some (Buffer.contents buffer, stats)
 
 let output verbose file conv data points =
   let files, stats = Hashtbl.fold

--- a/src/report/reportGeneric.mli
+++ b/src/report/reportGeneric.mli
@@ -47,11 +47,9 @@ class type converter =
 (** The class type defining a generic output. *)
 
 val output :
-  (string -> unit) -> string -> converter -> (string -> string option) ->
-  (string, int array) Hashtbl.t -> (string, string) Hashtbl.t ->
+  (string -> unit) -> string -> converter -> (string, int array) Hashtbl.t ->
+  (string, string) Hashtbl.t ->
     unit
-(** [output verbose file conv resolver data points] writes the element for
-    [data] to file [file] using [conv] for data conversion, [verbose] for
-    verbose output. [resolver] associates the actual path to a given
-    filename. [points] gives the marshalled locations of the points in the
-    file. *)
+(** [output verbose file conv data points] writes the element for [data] to file
+    [file] using [conv] for data conversion, [verbose] for verbose output.
+    [points] gives the marshalled locations of the points in the file. *)

--- a/src/report/reportGeneric.mli
+++ b/src/report/reportGeneric.mli
@@ -48,8 +48,10 @@ class type converter =
 
 val output :
   (string -> unit) -> string -> converter -> (string -> string option) ->
-  (string, int array) Hashtbl.t ->
+  (string, int array) Hashtbl.t -> (string, string) Hashtbl.t ->
     unit
-(** [output verbose file conv resolver data] writes the element for [data]
-    to file [file] using [conv] for data conversion, [verbose] for verbose
-    output. [resolver] associates the actual path to a given filename. *)
+(** [output verbose file conv resolver data points] writes the element for
+    [data] to file [file] using [conv] for data conversion, [verbose] for
+    verbose output. [resolver] associates the actual path to a given
+    filename. [points] gives the marshalled locations of the points in the
+    file. *)

--- a/src/report/reportHTML.ml
+++ b/src/report/reportHTML.ml
@@ -542,14 +542,16 @@ let escape_line tab_size line offset points =
     line;
   Buffer.contents buff
 
-let output_html verbose tab_size title in_file out_file resolver visited =
+let output_html
+    verbose tab_size title in_file out_file resolver visited points =
+
   verbose (Printf.sprintf "Processing file '%s'..." in_file);
   match resolver in_file with
   | None ->
     verbose "... file not found";
     None
   | Some resolved_in_file ->
-    let cmp_content = Common.read_points resolved_in_file in
+    let cmp_content = Hashtbl.find points in_file |> Common.read_points' in
     verbose (Printf.sprintf "... file has %d points" (List.length cmp_content));
     let len = Array.length visited in
     let stats = ReportStat.make () in
@@ -702,7 +704,7 @@ let output_html verbose tab_size title in_file out_file resolver visited =
     close_out_noerr out_channel;
     Some stats
 
-let output verbose dir tab_size title resolver data =
+let output verbose dir tab_size title resolver data points =
   let files = Hashtbl.fold
       (fun in_file visited acc ->
         let l = List.length acc in
@@ -710,7 +712,7 @@ let output verbose dir tab_size title resolver data =
         let out_file = (Filename.concat dir basename) ^ ".html" in
         let maybe_stats =
           output_html verbose tab_size title in_file out_file resolver
-            visited
+            visited points
         in
         match maybe_stats with
         | None -> acc

--- a/src/report/reportHTML.mli
+++ b/src/report/reportHTML.mli
@@ -21,10 +21,11 @@
 
 val output :
   (string -> unit) -> string -> int -> string -> (string -> string option) ->
-  (string, int array) Hashtbl.t ->
+  (string, int array) Hashtbl.t -> (string, string) Hashtbl.t ->
     unit
-(** [output verbose dir tab_size title resolver data] writes all the HTML files
-    for [data] in the directory [dir]. [verbose] is used for verbose output,
-    [tab_size] is the number of space characters to use as a replacement for
-    tabulations, [title] is the title for generated pages, and [resolver]
-    associates actual paths to given filenames. *)
+(** [output verbose dir tab_size title resolver data points] writes all the HTML
+    files for [data] in the directory [dir]. [verbose] is used for verbose
+    output, [tab_size] is the number of space characters to use as a replacement
+    for tabulations, [title] is the title for generated pages, and [resolver]
+    associates actual paths to given filenames. [points] gives the marshalled
+    locations of the points in the file. *)

--- a/src/syntax/instrumentPpx.ml
+++ b/src/syntax/instrumentPpx.ml
@@ -297,7 +297,7 @@ let faster file =
   let init =
     apply_nolabs
       (lid ((!InstrumentArgs.runtime_name) ^ ".Runtime.init_with_array"))
-      [strconst file; ilid "marks"]
+      [strconst file; ilid "marks"; ilid "points"]
   in
   let make = apply_nolabs (lid "Array.make") [intconst nb; intconst 0] in
   let marks =
@@ -332,6 +332,13 @@ let faster file =
   let e =
     Exp.(let_ Nonrecursive vb (sequence marks func))
   in
+  let points_string =
+    InstrumentState.get_points_for_file file
+    |> Common.write_points
+    |> strconst
+  in
+  let vb = [Vb.mk (pattern_var "points") points_string] in
+  let e = Exp.(let_ Nonrecursive vb e) in
   Str.value Nonrecursive [ Vb.mk (pattern_var (custom_mark_function file)) e]
 
 (* The actual "instrumenter" object, marking expressions. *)

--- a/src/syntax/instrumentState.ml
+++ b/src/syntax/instrumentState.ml
@@ -19,29 +19,11 @@
 (** List of marked points (identifiers are stored). *)
 let marked_points = ref []
 
-(* List of files with a call to either "Bisect.Runtime.init" or
-   "Bisect.Runtime.init_with_array". *)
+(* List of files with a call to [Bisect.Runtime.init_with_array]. *)
 let files = ref []
 
 (* Map from file name to list of point definitions. *)
 let points : (string, (Common.point_definition list)) Hashtbl.t = Hashtbl.create 17
-
-(* Dumps the points to their respective files. *)
-let () =
-  at_exit
-    (fun () ->
-      List.iter
-        (fun f ->
-          if not (Hashtbl.mem points f) then
-            Hashtbl.add points f [])
-        !files;
-      Hashtbl.iter
-        (fun file points ->
-          Common.try_out_channel
-            true
-            (Common.cmp_file_of_ml_file file)
-            (fun channel -> Common.write_points channel points file))
-        points)
 
 let get_points_for_file file =
   try

--- a/src/syntax/instrumentState.mli
+++ b/src/syntax/instrumentState.mli
@@ -17,8 +17,7 @@
  *)
 
 (** This stateful module maintains the information about files and points
-    that have been used by an instrumenter. It also registers a callback
-    to write this information at program termination. *)
+    that have been used by an instrumenter. *)
 
 val get_points_for_file : string -> Common.point_definition list
 (** Returns the list of point definitions for the passed file, an empty

--- a/tests/comments/source.ml.reference
+++ b/tests/comments/source.ml.reference
@@ -1,21 +1,25 @@
 let ___bisect_mark___source =
-  let marks = Array.make 8 0 in
-  (Bisect.Runtime.init_with_array "source.ml" marks; marks.(1) <- 1);
+  let points =
+    "\132\149\166\190\000\000\000,\000\000\000\t\000\000\000!\000\000\000!\b\000\000 \000\160\000uC\160\001\000\134B\160\001\000\158@\160\001\000\194A\160\001\001\181D\160\001\001\197E\160\001\001\229F\160\001\002\007G"
+     in
+  let marks = Array.make 8 0  in
+  (Bisect.Runtime.init_with_array "source.ml" marks points; marks.(1) <- 1);
   (function
    | idx ->
-       let curr = marks.(idx) in
+       let curr = marks.(idx)  in
        marks.(idx) <-
-       if curr < Pervasives.max_int then Pervasives.succ curr else curr)
-let f1 x y = if x = y then x + y else x - y
+         (if curr < Pervasives.max_int then Pervasives.succ curr else curr))
+  
+let f1 x y = if x = y then x + y else x - y 
 let g s =
   ___bisect_mark___source 3;
   if true
   then
     (___bisect_mark___source 2;
      for i = 1 to 5 do (___bisect_mark___source 0; print_endline s) done)
-  else (___bisect_mark___source 1; assert false)
-let f2 b x = if b then x * x else x
-let s1 = ___bisect_mark___source 4; "\\\\"
-let s2 = ___bisect_mark___source 5; '"'
-let s3 = ___bisect_mark___source 6; '"'
-let s4 = ___bisect_mark___source 7; "a\"a"
+  else (___bisect_mark___source 1; assert false) 
+let f2 b x = if b then x * x else x 
+let s1 = ___bisect_mark___source 4; "\\\\" 
+let s2 = ___bisect_mark___source 5; '"' 
+let s3 = ___bisect_mark___source 6; '"' 
+let s4 = ___bisect_mark___source 7; "a\"a" 

--- a/tests/exclude-file/source.ml.reference
+++ b/tests/exclude-file/source.ml.reference
@@ -1,14 +1,19 @@
 let ___bisect_mark___source =
-  let marks = Array.make 2 0 in
-  Bisect.Runtime.init_with_array "source.ml" marks;
+  let points =
+    "\132\149\166\190\000\000\000\t\000\000\000\003\000\000\000\t\000\000\000\t\160\160\000EA\160\000[@"
+     in
+  let marks = Array.make 2 0  in
+  Bisect.Runtime.init_with_array "source.ml" marks points;
   (function
    | idx ->
-       let curr = marks.(idx) in
+       let curr = marks.(idx)  in
        marks.(idx) <-
-       if curr < Pervasives.max_int then Pervasives.succ curr else curr)
-let f1 x y = if x = y then x + y else x - y
+         (if curr < Pervasives.max_int then Pervasives.succ curr else curr))
+  
+let f1 x y = if x = y then x + y else x - y 
 let g s =
   ___bisect_mark___source 1;
-  for i = 1 to 5 do (___bisect_mark___source 0; print_endline s) done
-let f2 b x = if b then x * x else x
-let f3 : 'a . 'a -> string= fun (type a) -> (fun _  -> "Hello" : a -> string)
+  for i = 1 to 5 do (___bisect_mark___source 0; print_endline s) done 
+let f2 b x = if b then x * x else x 
+let f3 : 'a . 'a -> string = fun (type a) ->
+  (fun _  -> "Hello" : a -> string) 

--- a/tests/exclude/source.ml.reference
+++ b/tests/exclude/source.ml.reference
@@ -1,13 +1,17 @@
 let ___bisect_mark___source =
-  let marks = Array.make 2 0 in
-  Bisect.Runtime.init_with_array "source.ml" marks;
+  let points =
+    "\132\149\166\190\000\000\000\t\000\000\000\003\000\000\000\t\000\000\000\t\160\160\000EA\160\000[@"
+     in
+  let marks = Array.make 2 0  in
+  Bisect.Runtime.init_with_array "source.ml" marks points;
   (function
    | idx ->
-       let curr = marks.(idx) in
+       let curr = marks.(idx)  in
        marks.(idx) <-
-       if curr < Pervasives.max_int then Pervasives.succ curr else curr)
-let f1 x y = if x = y then x + y else x - y
+         (if curr < Pervasives.max_int then Pervasives.succ curr else curr))
+  
+let f1 x y = if x = y then x + y else x - y 
 let g s =
   ___bisect_mark___source 1;
-  for i = 1 to 5 do (___bisect_mark___source 0; print_endline s) done
-let f2 b x = if b then x * x else x
+  for i = 1 to 5 do (___bisect_mark___source 0; print_endline s) done 
+let f2 b x = if b then x * x else x 

--- a/tests/instrument/expr_binding.ml.reference
+++ b/tests/instrument/expr_binding.ml.reference
@@ -1,28 +1,34 @@
 let ___bisect_mark___expr_binding =
-  let marks = Array.make 15 0 in
-  Bisect.Runtime.init_with_array "expr_binding.ml" marks;
+  let points =
+    "\132\149\166\190\000\000\000E\000\000\000\016\000\000\000=\000\000\000=\b\000\000<\000\160H@\160SA\160fB\160}C\160\000[F\160\000dD\160\000|E\160\001\000\156G\160\001\000\184I\160\001\000\203H\160\001\000\231N\160\001\000\241L\160\001\000\248M\160\001\001\003J\160\001\001\nK"
+     in
+  let marks = Array.make 15 0  in
+  Bisect.Runtime.init_with_array "expr_binding.ml" marks points;
   (function
    | idx ->
-       let curr = marks.(idx) in
+       let curr = marks.(idx)  in
        marks.(idx) <-
-       if curr < Pervasives.max_int then Pervasives.succ curr else curr)
-let x = ___bisect_mark___expr_binding 0; 3
-let y = ___bisect_mark___expr_binding 1; [1; 2; 3]
-let z = ___bisect_mark___expr_binding 2; [|1;2;3|]
-let f x = ___bisect_mark___expr_binding 3; print_endline x
+         (if curr < Pervasives.max_int then Pervasives.succ curr else curr))
+  
+let x = ___bisect_mark___expr_binding 0; 3 
+let y = ___bisect_mark___expr_binding 1; [1; 2; 3] 
+let z = ___bisect_mark___expr_binding 2; [|1;2;3|] 
+let f x = ___bisect_mark___expr_binding 3; print_endline x 
 let f' x =
   ___bisect_mark___expr_binding 6;
-  (let x' = ___bisect_mark___expr_binding 4; String.uppercase x in
+  (let x' = ___bisect_mark___expr_binding 4; String.uppercase x  in
    ___bisect_mark___expr_binding 5; print_endline x')
-let g x y z = ___bisect_mark___expr_binding 7; (x + y) * z
+  
+let g x y z = ___bisect_mark___expr_binding 7; (x + y) * z 
 let g' x y =
   ___bisect_mark___expr_binding 9;
   print_endline x;
   ___bisect_mark___expr_binding 8;
-  print_endline y
+  print_endline y 
 let () =
   ___bisect_mark___expr_binding 14;
-  (let f _ = ___bisect_mark___expr_binding 12; 0 in
+  (let f _ = ___bisect_mark___expr_binding 12; 0  in
    ___bisect_mark___expr_binding 13;
-   (let _g _ = ___bisect_mark___expr_binding 10; 1 in
+   (let _g _ = ___bisect_mark___expr_binding 10; 1  in
     ___bisect_mark___expr_binding 11; print_endline (string_of_int (f ()))))
+  

--- a/tests/instrument/expr_class.ml.reference
+++ b/tests/instrument/expr_class.ml.reference
@@ -1,11 +1,15 @@
 let ___bisect_mark___expr_class =
-  let marks = Array.make 18 0 in
-  Bisect.Runtime.init_with_array "expr_class.ml" marks;
+  let points =
+    "\132\149\166\190\000\000\000X\000\000\000\019\000\000\000I\000\000\000I\b\000\000H\000\160c@\160vA\160\000LB\160\000eC\160\000\127D\160\001\000\164E\160\001\000\207F\160\001\000\226G\160\001\000\248I\160\001\001\018H\160\001\001+K\160\001\0018J\160\001\001WM\160\001\001oL\160\001\001\141N\160\001\001\221O\160\001\002\017P\160\001\0026Q"
+     in
+  let marks = Array.make 18 0  in
+  Bisect.Runtime.init_with_array "expr_class.ml" marks points;
   (function
    | idx ->
-       let curr = marks.(idx) in
+       let curr = marks.(idx)  in
        marks.(idx) <-
-       if curr < Pervasives.max_int then Pervasives.succ curr else curr)
+         (if curr < Pervasives.max_int then Pervasives.succ curr else curr))
+  
 class c =
   object
     val mutable x = ___bisect_mark___expr_class 0; 0
@@ -14,7 +18,7 @@ class c =
     method print = ___bisect_mark___expr_class 3; print_int x
     initializer ___bisect_mark___expr_class 4; print_endline "created"
   end
-let i = ___bisect_mark___expr_class 5; new c
+let i = ___bisect_mark___expr_class 5; new c 
 class c' =
   object
     val mutable x = ___bisect_mark___expr_class 6; 0
@@ -35,7 +39,7 @@ class c' =
       ___bisect_mark___expr_class 12;
       print_newline ()
   end
-let i = ___bisect_mark___expr_class 14; new c
+let i = ___bisect_mark___expr_class 14; new c 
 class virtual c'' =
   object
     method virtual  get_x : int

--- a/tests/instrument/expr_doubleslashedquotes.ml.reference
+++ b/tests/instrument/expr_doubleslashedquotes.ml.reference
@@ -1,16 +1,21 @@
 let ___bisect_mark___expr_doubleslashedquotes =
-  let marks = Array.make 3 0 in
-  Bisect.Runtime.init_with_array "expr_doubleslashedquotes.ml" marks;
+  let points =
+    "\132\149\166\190\000\000\000\011\000\000\000\004\000\000\000\r\000\000\000\r\176\160oB\160|@\160\000SA"
+     in
+  let marks = Array.make 3 0  in
+  Bisect.Runtime.init_with_array "expr_doubleslashedquotes.ml" marks points;
   (function
    | idx ->
-       let curr = marks.(idx) in
+       let curr = marks.(idx)  in
        marks.(idx) <-
-       if curr < Pervasives.max_int then Pervasives.succ curr else curr)
+         (if curr < Pervasives.max_int then Pervasives.succ curr else curr))
+  
 type t =
-  | Anthony
-  | Caesar
+  | Anthony 
+  | Caesar 
 let message =
   ___bisect_mark___expr_doubleslashedquotes 2;
   (function
    | Anthony  -> (___bisect_mark___expr_doubleslashedquotes 0; "foo\\")
    | Caesar  -> (___bisect_mark___expr_doubleslashedquotes 1; "\\bar"))
+  

--- a/tests/instrument/expr_for.ml.reference
+++ b/tests/instrument/expr_for.ml.reference
@@ -1,11 +1,15 @@
 let ___bisect_mark___expr_for =
-  let marks = Array.make 10 0 in
-  Bisect.Runtime.init_with_array "expr_for.ml" marks;
+  let points =
+    "\132\149\166\190\000\000\000/\000\000\000\011\000\000\000)\000\000\000)\b\000\000(\000\160KE\160eD\160|B\160\000UA\160\000n@\160\001\000\140C\160\001\000\174I\160\001\000\200H\160\001\000\223F\160\001\000\253G"
+     in
+  let marks = Array.make 10 0  in
+  Bisect.Runtime.init_with_array "expr_for.ml" marks points;
   (function
    | idx ->
-       let curr = marks.(idx) in
+       let curr = marks.(idx)  in
        marks.(idx) <-
-       if curr < Pervasives.max_int then Pervasives.succ curr else curr)
+         (if curr < Pervasives.max_int then Pervasives.succ curr else curr))
+  
 let () =
   ___bisect_mark___expr_for 5;
   print_endline "before";
@@ -19,11 +23,11 @@ let () =
      print_endline "ghi")
   done;
   ___bisect_mark___expr_for 3;
-  print_endline "after"
+  print_endline "after" 
 let () =
   ___bisect_mark___expr_for 9;
   print_endline "before";
   ___bisect_mark___expr_for 8;
   for _i = 1 to 3 do (___bisect_mark___expr_for 6; print_endline "abc") done;
   ___bisect_mark___expr_for 7;
-  print_endline "after"
+  print_endline "after" 

--- a/tests/instrument/expr_ifthen.ml.reference
+++ b/tests/instrument/expr_ifthen.ml.reference
@@ -1,16 +1,20 @@
 let ___bisect_mark___expr_ifthen =
-  let marks = Array.make 11 0 in
-  Bisect.Runtime.init_with_array "expr_ifthen.ml" marks;
+  let points =
+    "\132\149\166\190\000\000\0004\000\000\000\012\000\000\000-\000\000\000-\b\000\000,\000\160KB\160\\A\160{@\160\000[G\160\000lF\160\001\000\129D\160\001\000\158E\160\001\000\179C\160\001\000\209J\160\001\000\226I\160\001\000\247H"
+     in
+  let marks = Array.make 11 0  in
+  Bisect.Runtime.init_with_array "expr_ifthen.ml" marks points;
   (function
    | idx ->
-       let curr = marks.(idx) in
+       let curr = marks.(idx)  in
        marks.(idx) <-
-       if curr < Pervasives.max_int then Pervasives.succ curr else curr)
+         (if curr < Pervasives.max_int then Pervasives.succ curr else curr))
+  
 let () =
   ___bisect_mark___expr_ifthen 2;
   if true
   then (___bisect_mark___expr_ifthen 1; print_endline "abc")
-  else (___bisect_mark___expr_ifthen 0; print_endline "def")
+  else (___bisect_mark___expr_ifthen 0; print_endline "def") 
 let () =
   ___bisect_mark___expr_ifthen 7;
   if true
@@ -24,6 +28,7 @@ let () =
      print_string "def";
      ___bisect_mark___expr_ifthen 3;
      print_newline ())
+  
 let () =
   ___bisect_mark___expr_ifthen 10;
   if true
@@ -32,3 +37,4 @@ let () =
      print_string "abc";
      ___bisect_mark___expr_ifthen 8;
      print_newline ())
+  

--- a/tests/instrument/expr_lazyop.ml.reference
+++ b/tests/instrument/expr_lazyop.ml.reference
@@ -1,14 +1,20 @@
 let ___bisect_mark___expr_lazyop =
-  let marks = Array.make 4 0 in
-  Bisect.Runtime.init_with_array "expr_lazyop.ml" marks;
+  let points =
+    "\132\149\166\190\000\000\000\r\000\000\000\005\000\000\000\017\000\000\000\017\192\160LA\160W@\160lC\160wB"
+     in
+  let marks = Array.make 4 0  in
+  Bisect.Runtime.init_with_array "expr_lazyop.ml" marks points;
   (function
    | idx ->
-       let curr = marks.(idx) in
+       let curr = marks.(idx)  in
        marks.(idx) <-
-       if curr < Pervasives.max_int then Pervasives.succ curr else curr)
+         (if curr < Pervasives.max_int then Pervasives.succ curr else curr))
+  
 let f x y =
   (___bisect_mark___expr_lazyop 1; x > 0) &&
     (___bisect_mark___expr_lazyop 0; y > 0)
+  
 let g x y =
   (___bisect_mark___expr_lazyop 3; x > 0) ||
     (___bisect_mark___expr_lazyop 2; y > 0)
+  

--- a/tests/instrument/expr_match.ml.reference
+++ b/tests/instrument/expr_match.ml.reference
@@ -1,23 +1,29 @@
 let ___bisect_mark___expr_match =
-  let marks = Array.make 101 0 in
-  Bisect.Runtime.init_with_array "expr_match.ml" marks;
+  let points =
+    "\132\149\166\190\000\000\002\027\000\000\000f\000\000\001\149\000\000\001\149\b\000\001\148\000\160LC\160]@\160zA\160\000WB\160\000yG\160\001\000\134D\160\001\000\163E\160\001\000\192F\160\001\000\230N\160\001\000\247K\160\001\001\016H\160\001\001%L\160\001\001>I\160\001\001SM\160\001\001lJ\160\001\001\134U\160\001\001\147R\160\001\001\172O\160\001\001\193S\160\001\001\218P\160\001\001\239T\160\001\002\bQ\160\001\002@Z\160\001\002QX\160\001\002lV\160\001\002\129Y\160\001\002\156W\160\001\002\182_\160\001\002\195]\160\001\002\222[\160\001\002\243^\160\001\003\014\\\160\001\003,d\160\001\003:`\160\001\003Ka\160\001\003bb\160\001\003rc\160\001\003\144i\160\001\003\161g\160\001\003\192h\160\001\003\222e\160\001\004\002f\160\001\004-l\160\001\004>j\160\001\004Dk\160\001\004lo\160\001\004}m\160\001\004\136n\160\001\004\181t\160\001\004\199p\160\001\004\205s\160\001\004\212q\160\001\004\218r\160\001\005\003w\160\001\005\020u\160\001\0058v\160\001\005^z\160\001\005ox\160\001\005\141y\160\001\005\202|\160\001\005\219{\160\001\006\027~\160\001\006,}\160\001\006_\000A\160\001\006p\127\160\001\006v\000@\160\001\006\145\000F\160\001\006\162\000B\160\001\006\163\000C\160\001\006\169\000D\160\001\006\204\000E\160\001\006\243\000J\160\001\007\004\000G\160\001\007(\000H\160\001\007.\000I\160\001\007p\000O\160\001\007\135\000K\160\001\007\141\000N\160\001\007\152\000L\160\001\007\158\000M\160\001\007\200\000W\160\001\007\217\000P\160\001\007\249\000Q\160\001\007\252\000R\160\001\b\002\000U\160\001\b\t\000S\160\001\b\015\000T\160\001\b4\000V\160\001\bW\000Z\160\001\bn\000X\160\001\bt\000Y\160\001\b\177\000^\160\001\b\209\000[\160\001\b\215\000\\\160\001\b\247\000]\160\001\t\029\000a\160\001\t.\000_\160\001\t;\000`\160\001\tX\000d\160\001\ti\000b\160\001\tr\000c"
+     in
+  let marks = Array.make 101 0  in
+  Bisect.Runtime.init_with_array "expr_match.ml" marks points;
   (function
    | idx ->
-       let curr = marks.(idx) in
+       let curr = marks.(idx)  in
        marks.(idx) <-
-       if curr < Pervasives.max_int then Pervasives.succ curr else curr)
+         (if curr < Pervasives.max_int then Pervasives.succ curr else curr))
+  
 let f x =
   ___bisect_mark___expr_match 3;
   (match x with
    | 0 -> (___bisect_mark___expr_match 0; print_endline "abc")
    | 1 -> (___bisect_mark___expr_match 1; print_endline "def")
    | _ -> (___bisect_mark___expr_match 2; print_endline "ghi"))
+  
 let f =
   ___bisect_mark___expr_match 7;
   (function
    | 0 -> (___bisect_mark___expr_match 4; print_endline "abc")
    | 1 -> (___bisect_mark___expr_match 5; print_endline "def")
    | _ -> (___bisect_mark___expr_match 6; print_endline "ghi"))
+  
 let f x =
   ___bisect_mark___expr_match 14;
   (match x with
@@ -36,6 +42,7 @@ let f x =
         print_string "ghi";
         ___bisect_mark___expr_match 10;
         print_newline ()))
+  
 let f =
   ___bisect_mark___expr_match 21;
   (function
@@ -54,9 +61,10 @@ let f =
         print_string "ghi";
         ___bisect_mark___expr_match 17;
         print_newline ()))
+  
 type t =
-  | Foo
-  | Bar
+  | Foo 
+  | Bar 
 let f x =
   ___bisect_mark___expr_match 26;
   (match x with
@@ -70,6 +78,7 @@ let f x =
         print_string "bar";
         ___bisect_mark___expr_match 23;
         print_newline ()))
+  
 let f =
   ___bisect_mark___expr_match 31;
   (function
@@ -83,6 +92,7 @@ let f =
         print_string "bar";
         ___bisect_mark___expr_match 28;
         print_newline ()))
+  
 let f x =
   ___bisect_mark___expr_match 36;
   ((function
@@ -90,7 +100,7 @@ let f x =
     | Bar  -> (___bisect_mark___expr_match 33; "bar")) x) |>
     ((___bisect_mark___expr_match 34; print_string));
   ___bisect_mark___expr_match 35;
-  print_newline ()
+  print_newline () 
 let f x =
   ___bisect_mark___expr_match 41;
   (match x with
@@ -100,6 +110,7 @@ let f x =
         (match x with
          | Foo  -> (___bisect_mark___expr_match 37; print_endline "foobar")
          | Bar  -> (___bisect_mark___expr_match 38; print_endline "barbar"))))
+  
 let f x =
   ___bisect_mark___expr_match 44;
   (match x with
@@ -107,8 +118,10 @@ let f x =
        ((((match ___bisect_matched_value___ with
            | Foo  -> (___bisect_mark___expr_match 42; ())
            | Bar  -> (___bisect_mark___expr_match 43; ())
-           | _ -> ()))[@ocaml.warning "-4-8-9-11-26-27-28"]);
+           | _ -> ()))
+        [@ocaml.warning "-4-8-9-11-26-27-28"]);
         print_endline "foo"))
+  
 let f x =
   ___bisect_mark___expr_match 47;
   (match x with
@@ -116,8 +129,10 @@ let f x =
        ((((match ___bisect_matched_value___ with
            | (Foo ,_) -> (___bisect_mark___expr_match 45; ())
            | (Bar ,_) -> (___bisect_mark___expr_match 46; ())
-           | _ -> ()))[@ocaml.warning "-4-8-9-11-26-27-28"]);
+           | _ -> ()))
+        [@ocaml.warning "-4-8-9-11-26-27-28"]);
         print_endline "foo"))
+  
 let f x =
   ___bisect_mark___expr_match 52;
   (match x with
@@ -139,28 +154,34 @@ let f x =
                (___bisect_mark___expr_match 50;
                 ___bisect_mark___expr_match 51;
                 ())
-           | _ -> ()))[@ocaml.warning "-4-8-9-11-26-27-28"]);
+           | _ -> ()))
+        [@ocaml.warning "-4-8-9-11-26-27-28"]);
         print_endline "foo"))
+  
 let f x =
   ___bisect_mark___expr_match 55;
   (match x with
    | 'a'..'z' -> (___bisect_mark___expr_match 53; print_endline "foo")
    | _ -> (___bisect_mark___expr_match 54; print_endline "bar"))
+  
 let f x =
   ___bisect_mark___expr_match 58;
   (match x with
    | `A -> (___bisect_mark___expr_match 56; print_endline "foo")
    | `B -> (___bisect_mark___expr_match 57; print_endline "bar"))
+  
 type u = [ `A  | `B ]
 let f x =
   ___bisect_mark___expr_match 60;
   (match x with | #u -> (___bisect_mark___expr_match 59; print_endline "foo"))
+  
 module type S  = sig  end
 let f x =
   ___bisect_mark___expr_match 62;
   (match x with
    | ((module X)  : (module S)) ->
        (___bisect_mark___expr_match 61; print_endline "foo"))
+  
 let f x =
   ___bisect_mark___expr_match 65;
   (match x with
@@ -168,8 +189,10 @@ let f x =
        ((((match ___bisect_matched_value___ with
            | Foo  as y -> (___bisect_mark___expr_match 63; ())
            | Bar  as y -> (___bisect_mark___expr_match 64; ())
-           | _ -> ()))[@ocaml.warning "-4-8-9-11-26-27-28"]);
+           | _ -> ()))
+        [@ocaml.warning "-4-8-9-11-26-27-28"]);
         y))
+  
 let f x =
   ___bisect_mark___expr_match 70;
   (match x with
@@ -183,9 +206,11 @@ let f x =
                (___bisect_mark___expr_match 68;
                 ___bisect_mark___expr_match 66;
                 ())
-           | _ -> ()))[@ocaml.warning "-4-8-9-11-26-27-28"]);
+           | _ -> ()))
+        [@ocaml.warning "-4-8-9-11-26-27-28"]);
         print_endline "foo")
    | [] -> (___bisect_mark___expr_match 69; print_endline "bar"))
+  
 let f x =
   ___bisect_mark___expr_match 74;
   (match x with
@@ -194,11 +219,13 @@ let f x =
        ((((match ___bisect_matched_value___ with
            | `B (Foo ) -> (___bisect_mark___expr_match 72; ())
            | `B (Bar ) -> (___bisect_mark___expr_match 73; ())
-           | _ -> ()))[@ocaml.warning "-4-8-9-11-26-27-28"]);
+           | _ -> ()))
+        [@ocaml.warning "-4-8-9-11-26-27-28"]);
         print_endline "bar"))
+  
 type v = {
-  a: t;
-  b: t;}
+  a: t ;
+  b: t }
 let f x =
   ___bisect_mark___expr_match 79;
   (match x with
@@ -220,8 +247,10 @@ let f x =
                (___bisect_mark___expr_match 77;
                 ___bisect_mark___expr_match 78;
                 ())
-           | _ -> ()))[@ocaml.warning "-4-8-9-11-26-27-28"]);
+           | _ -> ()))
+        [@ocaml.warning "-4-8-9-11-26-27-28"]);
         print_endline "foo"))
+  
 let f x =
   ___bisect_mark___expr_match 87;
   (match x with
@@ -248,9 +277,11 @@ let f x =
                 ___bisect_mark___expr_match 85;
                 ___bisect_mark___expr_match 81;
                 ())
-           | _ -> ()))[@ocaml.warning "-4-8-9-11-26-27-28"]);
+           | _ -> ()))
+        [@ocaml.warning "-4-8-9-11-26-27-28"]);
         print_endline "bar")
    | _ -> (___bisect_mark___expr_match 86; print_newline ()))
+  
 let f x =
   ___bisect_mark___expr_match 90;
   (match x with
@@ -258,9 +289,11 @@ let f x =
        ((((match ___bisect_matched_value___ with
            | (lazy Foo ) -> (___bisect_mark___expr_match 88; ())
            | (lazy Bar ) -> (___bisect_mark___expr_match 89; ())
-           | _ -> ()))[@ocaml.warning "-4-8-9-11-26-27-28"]);
+           | _ -> ()))
+        [@ocaml.warning "-4-8-9-11-26-27-28"]);
         print_endline "foo"))
-exception Exn of t
+  
+exception Exn of t 
 let f x =
   ___bisect_mark___expr_match 94;
   (match x with
@@ -268,9 +301,11 @@ let f x =
        ((((match ___bisect_matched_value___ with
            | Exn (Foo ) -> (___bisect_mark___expr_match 91; ())
            | Exn (Bar ) -> (___bisect_mark___expr_match 92; ())
-           | _ -> ()))[@ocaml.warning "-4-8-9-11-26-27-28"]);
+           | _ -> ()))
+        [@ocaml.warning "-4-8-9-11-26-27-28"]);
         print_endline "foo")
    | _ -> (___bisect_mark___expr_match 93; print_endline "bar"))
+  
 let f x =
   ___bisect_mark___expr_match 97;
   (match x with
@@ -278,8 +313,10 @@ let f x =
        ((((match ___bisect_matched_value___ with
            | Foo  as x -> (___bisect_mark___expr_match 95; ())
            | Bar  as x -> (___bisect_mark___expr_match 96; ())
-           | _ -> ()))[@ocaml.warning "-4-8-9-11-26-27-28"]);
+           | _ -> ()))
+        [@ocaml.warning "-4-8-9-11-26-27-28"]);
         x))
+  
 let f x =
   ___bisect_mark___expr_match 100;
   (match x with
@@ -287,5 +324,7 @@ let f x =
        ((((match ___bisect_matched_value___ with
            | `Foo x -> (___bisect_mark___expr_match 98; ())
            | `Bar x -> (___bisect_mark___expr_match 99; ())
-           | _ -> ()))[@ocaml.warning "-4-8-9-11-26-27-28"]);
+           | _ -> ()))
+        [@ocaml.warning "-4-8-9-11-26-27-28"]);
         x))
+  

--- a/tests/instrument/expr_polyrec.ml.reference
+++ b/tests/instrument/expr_polyrec.ml.reference
@@ -1,25 +1,32 @@
 let ___bisect_mark___expr_polyrec =
-  let marks = Array.make 8 0 in
-  Bisect.Runtime.init_with_array "expr_polyrec.ml" marks;
+  let points =
+    "\132\149\166\190\000\000\000$\000\000\000\t\000\000\000!\000\000\000!\b\000\000 \000\160_B\160lA\160u@\160\000FG\160\000gE\160\000vD\160\001\000\129C\160\001\000\139F"
+     in
+  let marks = Array.make 8 0  in
+  Bisect.Runtime.init_with_array "expr_polyrec.ml" marks points;
   (function
    | idx ->
-       let curr = marks.(idx) in
+       let curr = marks.(idx)  in
        marks.(idx) <-
-       if curr < Pervasives.max_int then Pervasives.succ curr else curr)
-let rec f : 'a . 'a -> unit=
+         (if curr < Pervasives.max_int then Pervasives.succ curr else curr))
+  
+let rec f : 'a . 'a -> unit =
   ___bisect_mark___expr_polyrec 2;
   (fun _  ->
      ___bisect_mark___expr_polyrec 1;
      f 0;
      ___bisect_mark___expr_polyrec 0;
      f "")
+  
 let () =
   ___bisect_mark___expr_polyrec 7;
-  (let rec f : 'a . 'a -> unit=
+  (let rec f : 'a . 'a -> unit =
      ___bisect_mark___expr_polyrec 5;
      (fun _  ->
         ___bisect_mark___expr_polyrec 4;
         f 0;
         ___bisect_mark___expr_polyrec 3;
-        f "") in
+        f "")
+      in
    ___bisect_mark___expr_polyrec 6; f 0)
+  

--- a/tests/instrument/expr_sequence.ml.reference
+++ b/tests/instrument/expr_sequence.ml.reference
@@ -1,24 +1,28 @@
 let ___bisect_mark___expr_sequence =
-  let marks = Array.make 15 0 in
-  Bisect.Runtime.init_with_array "expr_sequence.ml" marks;
+  let points =
+    "\132\149\166\190\000\000\000I\000\000\000\016\000\000\000=\000\000\000=\b\000\000<\000\160K@\160kB\160\000BA\160\000bE\160\000yD\160\001\000\144C\160\001\000\176J\160\001\000\211H\160\001\000\226F\160\001\001\002G\160\001\001&I\160\001\0019N\160\001\001KL\160\001\001]M\160\001\001cK"
+     in
+  let marks = Array.make 15 0  in
+  Bisect.Runtime.init_with_array "expr_sequence.ml" marks points;
   (function
    | idx ->
-       let curr = marks.(idx) in
+       let curr = marks.(idx)  in
        marks.(idx) <-
-       if curr < Pervasives.max_int then Pervasives.succ curr else curr)
-let () = ___bisect_mark___expr_sequence 0; print_endline "abc"
+         (if curr < Pervasives.max_int then Pervasives.succ curr else curr))
+  
+let () = ___bisect_mark___expr_sequence 0; print_endline "abc" 
 let () =
   ___bisect_mark___expr_sequence 2;
   print_endline "abc";
   ___bisect_mark___expr_sequence 1;
-  print_endline "def"
+  print_endline "def" 
 let () =
   ___bisect_mark___expr_sequence 5;
   print_endline "abc";
   ___bisect_mark___expr_sequence 4;
   print_endline "def";
   ___bisect_mark___expr_sequence 3;
-  print_endline "ghi"
+  print_endline "ghi" 
 let () =
   ___bisect_mark___expr_sequence 10;
   (print_endline "abc";
@@ -27,8 +31,10 @@ let () =
     | 0 -> (___bisect_mark___expr_sequence 6; print_endline "def")
     | _ -> (___bisect_mark___expr_sequence 7; print_endline "ghi"))) |>
     ((___bisect_mark___expr_sequence 9; ignore))
+  
 let () =
   ___bisect_mark___expr_sequence 14;
-  (let f ?maybe  () = ___bisect_mark___expr_sequence 12; ignore maybe in
+  (let f ?maybe  () = ___bisect_mark___expr_sequence 12; ignore maybe  in
    ___bisect_mark___expr_sequence 13;
    () |> ((___bisect_mark___expr_sequence 11; f)))
+  

--- a/tests/instrument/expr_try.ml.reference
+++ b/tests/instrument/expr_try.ml.reference
@@ -1,11 +1,15 @@
 let ___bisect_mark___expr_try =
-  let marks = Array.make 10 0 in
-  Bisect.Runtime.init_with_array "expr_try.ml" marks;
+  let points =
+    "\132\149\166\190\000\000\0000\000\000\000\011\000\000\000)\000\000\000)\b\000\000(\000\160KE\160eD\160\000GA\160\000bB\160\000|@\160\001\000\148C\160\001\000\182I\160\001\000\208H\160\001\000\244F\160\001\001\017G"
+     in
+  let marks = Array.make 10 0  in
+  Bisect.Runtime.init_with_array "expr_try.ml" marks points;
   (function
    | idx ->
-       let curr = marks.(idx) in
+       let curr = marks.(idx)  in
        marks.(idx) <-
-       if curr < Pervasives.max_int then Pervasives.succ curr else curr)
+         (if curr < Pervasives.max_int then Pervasives.succ curr else curr))
+  
 let () =
   ___bisect_mark___expr_try 5;
   print_endline "before";
@@ -18,7 +22,7 @@ let () =
         ___bisect_mark___expr_try 0;
         print_endline "DEF"));
   ___bisect_mark___expr_try 3;
-  print_endline "after"
+  print_endline "after" 
 let () =
   ___bisect_mark___expr_try 9;
   print_endline "before";
@@ -26,4 +30,4 @@ let () =
   (try print_endline "abc"
    with | _ -> (___bisect_mark___expr_try 6; print_endline "ABC"));
   ___bisect_mark___expr_try 7;
-  print_endline "after"
+  print_endline "after" 

--- a/tests/instrument/expr_while.ml.reference
+++ b/tests/instrument/expr_while.ml.reference
@@ -1,11 +1,15 @@
 let ___bisect_mark___expr_while =
-  let marks = Array.make 10 0 in
-  Bisect.Runtime.init_with_array "expr_while.ml" marks;
+  let points =
+    "\132\149\166\190\000\000\000/\000\000\000\011\000\000\000)\000\000\000)\b\000\000(\000\160KE\160eD\160wB\160\000PA\160\000i@\160\001\000\135C\160\001\000\169I\160\001\000\195H\160\001\000\213F\160\001\000\243G"
+     in
+  let marks = Array.make 10 0  in
+  Bisect.Runtime.init_with_array "expr_while.ml" marks points;
   (function
    | idx ->
-       let curr = marks.(idx) in
+       let curr = marks.(idx)  in
        marks.(idx) <-
-       if curr < Pervasives.max_int then Pervasives.succ curr else curr)
+         (if curr < Pervasives.max_int then Pervasives.succ curr else curr))
+  
 let () =
   ___bisect_mark___expr_while 5;
   print_endline "before";
@@ -19,11 +23,11 @@ let () =
      print_endline "ghi")
     done;
   ___bisect_mark___expr_while 3;
-  print_endline "after"
+  print_endline "after" 
 let () =
   ___bisect_mark___expr_while 9;
   print_endline "before";
   ___bisect_mark___expr_while 8;
   while true do (___bisect_mark___expr_while 6; print_endline "abc") done;
   ___bisect_mark___expr_while 7;
-  print_endline "after"
+  print_endline "after" 

--- a/tests/instrument/nested_module.ml.reference
+++ b/tests/instrument/nested_module.ml.reference
@@ -1,11 +1,15 @@
 let ___bisect_mark___nested_module =
-  let marks = Array.make 3 0 in
-  Bisect.Runtime.init_with_array "nested_module.ml" marks;
+  let points =
+    "\132\149\166\190\000\000\000\n\000\000\000\004\000\000\000\r\000\000\000\r\176\160H@\160iA\160~B"
+     in
+  let marks = Array.make 3 0  in
+  Bisect.Runtime.init_with_array "nested_module.ml" marks points;
   (function
    | idx ->
-       let curr = marks.(idx) in
+       let curr = marks.(idx)  in
        marks.(idx) <-
-       if curr < Pervasives.max_int then Pervasives.succ curr else curr)
-let x = ___bisect_mark___nested_module 0; 3
-module F = struct let y x = ___bisect_mark___nested_module 1; x + 4 end
-let z x = ___bisect_mark___nested_module 2; x + 5
+         (if curr < Pervasives.max_int then Pervasives.succ curr else curr))
+  
+let x = ___bisect_mark___nested_module 0; 3 
+module F = struct let y x = ___bisect_mark___nested_module 1; x + 4  end
+let z x = ___bisect_mark___nested_module 2; x + 5 

--- a/tests/line-number-directive/expr_binding.ml.reference
+++ b/tests/line-number-directive/expr_binding.ml.reference
@@ -1,22 +1,27 @@
 let ___bisect_mark___expr_binding =
-  let marks = Array.make 10 0 in
-  Bisect.Runtime.init_with_array "expr_binding.ml" marks;
+  let points =
+    "\132\149\166\190\000\000\000-\000\000\000\011\000\000\000)\000\000\000)\b\000\000(\000\160H@\160SA\160fB\160}C\160\000vF\160\000\127D\160\001\000\151E\160\001\000\183G\160\001\000\211I\160\001\000\230H"
+     in
+  let marks = Array.make 10 0  in
+  Bisect.Runtime.init_with_array "expr_binding.ml" marks points;
   (function
    | idx ->
-       let curr = marks.(idx) in
+       let curr = marks.(idx)  in
        marks.(idx) <-
-       if curr < Pervasives.max_int then Pervasives.succ curr else curr)
-let x = ___bisect_mark___expr_binding 0; 3
-let y = ___bisect_mark___expr_binding 1; [1; 2; 3]
-let z = ___bisect_mark___expr_binding 2; [|1;2;3|]
-let f x = ___bisect_mark___expr_binding 3; print_endline x
+         (if curr < Pervasives.max_int then Pervasives.succ curr else curr))
+  
+let x = ___bisect_mark___expr_binding 0; 3 
+let y = ___bisect_mark___expr_binding 1; [1; 2; 3] 
+let z = ___bisect_mark___expr_binding 2; [|1;2;3|] 
+let f x = ___bisect_mark___expr_binding 3; print_endline x 
 let f' x =
   ___bisect_mark___expr_binding 6;
-  (let x' = ___bisect_mark___expr_binding 4; String.uppercase x in
+  (let x' = ___bisect_mark___expr_binding 4; String.uppercase x  in
    ___bisect_mark___expr_binding 5; print_endline x')
-let g x y z = ___bisect_mark___expr_binding 7; (x + y) * z
+  
+let g x y z = ___bisect_mark___expr_binding 7; (x + y) * z 
 let g' x y =
   ___bisect_mark___expr_binding 9;
   print_endline x;
   ___bisect_mark___expr_binding 8;
-  print_endline y
+  print_endline y 

--- a/tests/line-number-directive/expr_comment.ml.reference
+++ b/tests/line-number-directive/expr_comment.ml.reference
@@ -1,15 +1,19 @@
 let ___bisect_mark___expr_comment =
-  let marks = Array.make 3 0 in
-  Bisect.Runtime.init_with_array "expr_comment.ml" marks;
+  let points =
+    "\132\149\166\190\000\000\000\n\000\000\000\004\000\000\000\r\000\000\000\r\176\160H@\160SA\160fB"
+     in
+  let marks = Array.make 3 0  in
+  Bisect.Runtime.init_with_array "expr_comment.ml" marks points;
   (function
    | idx ->
-       let curr = marks.(idx) in
+       let curr = marks.(idx)  in
        marks.(idx) <-
-       if curr < Pervasives.max_int then Pervasives.succ curr else curr)
-let x = ___bisect_mark___expr_comment 0; 3
-let y = ___bisect_mark___expr_comment 1; [1; 2; 3]
-let z = ___bisect_mark___expr_comment 2; [|1;2;3|]
-let f x = print_endline x
-let f' x = let x' = String.uppercase x in print_endline x'
-let g x y z = (x + y) * z
-let g' x y = print_endline x; print_endline y
+         (if curr < Pervasives.max_int then Pervasives.succ curr else curr))
+  
+let x = ___bisect_mark___expr_comment 0; 3 
+let y = ___bisect_mark___expr_comment 1; [1; 2; 3] 
+let z = ___bisect_mark___expr_comment 2; [|1;2;3|] 
+let f x = print_endline x 
+let f' x = let x' = String.uppercase x  in print_endline x' 
+let g x y z = (x + y) * z 
+let g' x y = print_endline x; print_endline y 

--- a/tests/missing-files/test_missing_files.ml
+++ b/tests/missing-files/test_missing_files.ml
@@ -6,7 +6,7 @@ let tests = "missing-files" >::: [
     run "echo 'let () = ()' > source.ml";
     compile (with_bisect () ^ " -package findlib.dynload") "_scratch/source.ml";
     run "./a.out";
-    report "-text /dev/null" ~r:"2> /dev/null || touch failed";
+    report "-html report" ~r:"2> /dev/null || touch failed";
     run "[ -f failed ]"
   end;
 
@@ -14,6 +14,6 @@ let tests = "missing-files" >::: [
     run "echo 'let () = ()' > source.ml";
     compile (with_bisect () ^ " -package findlib.dynload") "_scratch/source.ml";
     run "./a.out";
-    report "-ignore-missing-files -text /dev/null"
+    report "-ignore-missing-files -html report"
   end
 ]

--- a/tests/ppx-integration/attributes.reference
+++ b/tests/ppx-integration/attributes.reference
@@ -1,14 +1,18 @@
 let ___bisect_mark___attributes =
-  let marks = Array.make 22 0 in
-  Bisect.Runtime.init_with_array "attributes.ml" marks;
+  let points =
+    "\132\149\166\190\000\000\000d\000\000\000\023\000\000\000Y\000\000\000Y\b\000\000X\000\160KU\160TQ\160YR\160jS\160uT\160\127N\160\000PO\160\000[P\160\000{L\160\001\000\134M\160\001\000\152I\160\001\000\164J\160\001\000\188K\160\001\000\202E\160\001\000\213F\160\001\000\235G\160\001\000\246H\160\001\001\014B\160\001\001\028C\160\001\0014D\160\001\001BA\160\001\001J@"
+     in
+  let marks = Array.make 22 0  in
+  Bisect.Runtime.init_with_array "attributes.ml" marks points;
   (function
    | idx ->
-       let curr = marks.(idx) in
+       let curr = marks.(idx)  in
        marks.(idx) <-
-       if curr < Pervasives.max_int then Pervasives.succ curr else curr)
+         (if curr < Pervasives.max_int then Pervasives.succ curr else curr))
+  
 let () =
   ___bisect_mark___attributes 21;
-  ((let x = ___bisect_mark___attributes 17; 1 in
+  ((let x = ___bisect_mark___attributes 17; 1  in
     ___bisect_mark___attributes 18; x)[@testing ]) |>
     ((___bisect_mark___attributes 19; ignore));
   ___bisect_mark___attributes 20;
@@ -20,7 +24,8 @@ let () =
   ___bisect_mark___attributes 13;
   (((match 0 with
      | 0 -> (___bisect_mark___attributes 9; ())
-     | _ -> (___bisect_mark___attributes 10; ())))[@testing ]);
+     | _ -> (___bisect_mark___attributes 10; ())))
+  [@testing ]);
   ___bisect_mark___attributes 11;
   ((function
     | 0 -> (___bisect_mark___attributes 5; 0)
@@ -28,8 +33,10 @@ let () =
     ((___bisect_mark___attributes 7; ignore));
   ___bisect_mark___attributes 8;
   (((try (string_of_int 0) |> (___bisect_mark___attributes 2; ignore)
-     with | _ -> (___bisect_mark___attributes 3; ())))[@testing ]);
+     with | _ -> (___bisect_mark___attributes 3; ())))
+  [@testing ]);
   ___bisect_mark___attributes 4;
   ((if true
     then (___bisect_mark___attributes 1; ())
-    else (___bisect_mark___attributes 0; ()))[@testing ])
+    else (___bisect_mark___attributes 0; ()))
+  [@testing ]) 

--- a/tests/ppx-integration/bisect_then_blob.reference
+++ b/tests/ppx-integration/bisect_then_blob.reference
@@ -1,17 +1,23 @@
 let ___bisect_mark___blob =
-  let marks = Array.make 3 0 in
-  Bisect.Runtime.init_with_array "blob.ml" marks;
+  let points =
+    "\132\149\166\190\000\000\000\012\000\000\000\004\000\000\000\r\000\000\000\r\176\160L@\160\000EB\160\000ZA"
+     in
+  let marks = Array.make 3 0  in
+  Bisect.Runtime.init_with_array "blob.ml" marks points;
   (function
    | idx ->
-       let curr = marks.(idx) in
+       let curr = marks.(idx)  in
        marks.(idx) <-
-       if curr < Pervasives.max_int then Pervasives.succ curr else curr)
+         (if curr < Pervasives.max_int then Pervasives.succ curr else curr))
+  
 let me () =
   ___bisect_mark___blob 0;
   Printf.printf "ME: %s\n"
     "let me () = Printf.printf \"ME: %s\\n\" [%blob \"blob.ml\"]\n\nlet me' () = print_endline \"foo\"; [%blob \"blob.ml\"]\n"
+  
 let me' () =
   ___bisect_mark___blob 2;
   print_endline "foo";
   ___bisect_mark___blob 1;
   "let me () = Printf.printf \"ME: %s\\n\" [%blob \"blob.ml\"]\n\nlet me' () = print_endline \"foo\"; [%blob \"blob.ml\"]\n"
+  

--- a/tests/ppx-integration/bisect_then_deriving.reference
+++ b/tests/ppx-integration/bisect_then_deriving.reference
@@ -1,21 +1,27 @@
 let ___bisect_mark___deriving =
-  let marks = Array.make 3 0 in
-  Bisect.Runtime.init_with_array "deriving.ml" marks;
+  let points =
+    "\132\149\166\190\000\000\000\011\000\000\000\004\000\000\000\r\000\000\000\r\176\160I@\160vB\160\000DA"
+     in
+  let marks = Array.make 3 0  in
+  Bisect.Runtime.init_with_array "deriving.ml" marks points;
   (function
    | idx ->
-       let curr = marks.(idx) in
+       let curr = marks.(idx)  in
        marks.(idx) <-
-       if curr < Pervasives.max_int then Pervasives.succ curr else curr)
-let () = ___bisect_mark___deriving 0; ()
+         (if curr < Pervasives.max_int then Pervasives.succ curr else curr))
+  
+let () = ___bisect_mark___deriving 0; () 
 type a =
-  | Foo[@@deriving show]
+  | Foo [@@deriving show]
 let rec (pp_a : Format.formatter -> a -> Ppx_deriving_runtime.unit) =
   ((let open! Ppx_deriving_runtime in
       fun fmt  ->
         function | Foo  -> Format.pp_print_string fmt "Deriving.Foo")
   [@ocaml.warning "-A"])
-and show_a : a -> Ppx_deriving_runtime.string=
+
+and show_a : a -> Ppx_deriving_runtime.string =
   fun x  -> Format.asprintf "%a" pp_a x
+
 let () =
   ___bisect_mark___deriving 2;
-  (show_a Foo) |> ((___bisect_mark___deriving 1; print_endline))
+  (show_a Foo) |> ((___bisect_mark___deriving 1; print_endline)) 

--- a/tests/ppx-integration/blob_then_bisect.reference
+++ b/tests/ppx-integration/blob_then_bisect.reference
@@ -1,17 +1,23 @@
 let ___bisect_mark___blob =
-  let marks = Array.make 3 0 in
-  Bisect.Runtime.init_with_array "blob.ml" marks;
+  let points =
+    "\132\149\166\190\000\000\000\012\000\000\000\004\000\000\000\r\000\000\000\r\176\160L@\160\000EB\160\000aA"
+     in
+  let marks = Array.make 3 0  in
+  Bisect.Runtime.init_with_array "blob.ml" marks points;
   (function
    | idx ->
-       let curr = marks.(idx) in
+       let curr = marks.(idx)  in
        marks.(idx) <-
-       if curr < Pervasives.max_int then Pervasives.succ curr else curr)
+         (if curr < Pervasives.max_int then Pervasives.succ curr else curr))
+  
 let me () =
   ___bisect_mark___blob 0;
   Printf.printf "ME: %s\n"
     "let me () = Printf.printf \"ME: %s\\n\" [%blob \"blob.ml\"]\n\nlet me' () = print_endline \"foo\"; [%blob \"blob.ml\"]\n"
+  
 let me' () =
   ___bisect_mark___blob 2;
   print_endline "foo";
   ___bisect_mark___blob 1;
   "let me () = Printf.printf \"ME: %s\\n\" [%blob \"blob.ml\"]\n\nlet me' () = print_endline \"foo\"; [%blob \"blob.ml\"]\n"
+  

--- a/tests/ppx-integration/deriving_then_bisect.reference
+++ b/tests/ppx-integration/deriving_then_bisect.reference
@@ -1,23 +1,30 @@
 let ___bisect_mark___deriving =
-  let marks = Array.make 4 0 in
-  Bisect.Runtime.init_with_array "deriving.ml" marks;
+  let points =
+    "\132\149\166\190\000\000\000\014\000\000\000\005\000\000\000\017\000\000\000\017\192\160I@\160MA\160vC\160\000DB"
+     in
+  let marks = Array.make 4 0  in
+  Bisect.Runtime.init_with_array "deriving.ml" marks points;
   (function
    | idx ->
-       let curr = marks.(idx) in
+       let curr = marks.(idx)  in
        marks.(idx) <-
-       if curr < Pervasives.max_int then Pervasives.succ curr else curr)
-let () = ___bisect_mark___deriving 0; ()
+         (if curr < Pervasives.max_int then Pervasives.succ curr else curr))
+  
+let () = ___bisect_mark___deriving 0; () 
 type a =
-  | Foo[@@deriving show]
+  | Foo [@@deriving show]
 let rec (pp_a : Format.formatter -> a -> Ppx_deriving_runtime.unit) =
   ((let open! Ppx_deriving_runtime in
       fun fmt  ->
         function
         | Foo  ->
             (___bisect_mark___deriving 1;
-             Format.pp_print_string fmt "Deriving.Foo"))[@ocaml.warning "-A"])
-and show_a : a -> Ppx_deriving_runtime.string=
+             Format.pp_print_string fmt "Deriving.Foo"))
+  [@ocaml.warning "-A"])
+
+and show_a : a -> Ppx_deriving_runtime.string =
   fun x  -> Format.asprintf "%a" pp_a x
+
 let () =
   ___bisect_mark___deriving 3;
-  (show_a Foo) |> ((___bisect_mark___deriving 2; print_endline))
+  (show_a Foo) |> ((___bisect_mark___deriving 2; print_endline)) 

--- a/tests/simple-cases/source.ml.reference
+++ b/tests/simple-cases/source.ml.reference
@@ -1,13 +1,18 @@
 let ___bisect_mark___source =
-  let marks = Array.make 3 0 in
-  Bisect.Runtime.init_with_array "source.ml" marks;
+  let points =
+    "\132\149\166\190\000\000\000\n\000\000\000\004\000\000\000\r\000\000\000\r\176\160LB\160]@\160oA"
+     in
+  let marks = Array.make 3 0  in
+  Bisect.Runtime.init_with_array "source.ml" marks points;
   (function
    | idx ->
-       let curr = marks.(idx) in
+       let curr = marks.(idx)  in
        marks.(idx) <-
-       if curr < Pervasives.max_int then Pervasives.succ curr else curr)
+         (if curr < Pervasives.max_int then Pervasives.succ curr else curr))
+  
 let f x =
   ___bisect_mark___source 2;
   (match x with
    | `A|`B -> (___bisect_mark___source 0; ())
    | exception (Failure _|End_of_file ) -> (___bisect_mark___source 1; ()))
+  

--- a/tests/top-level/batch.reference
+++ b/tests/top-level/batch.reference
@@ -1,9 +1,13 @@
 let ___bisect_mark___source =
-  let marks = Array.make 1 0 in
-  Bisect.Runtime.init_with_array "source.ml" marks;
+  let points =
+    "\132\149\166\190\000\000\000\004\000\000\000\002\000\000\000\005\000\000\000\005\144\160I@"
+     in
+  let marks = Array.make 1 0  in
+  Bisect.Runtime.init_with_array "source.ml" marks points;
   (function
    | idx ->
-       let curr = marks.(idx) in
+       let curr = marks.(idx)  in
        marks.(idx) <-
-       if curr < Pervasives.max_int then Pervasives.succ curr else curr)
-let () = ___bisect_mark___source 0; print_endline "foo"
+         (if curr < Pervasives.max_int then Pervasives.succ curr else curr))
+  
+let () = ___bisect_mark___source 0; print_endline "foo" 


### PR DESCRIPTION
See the messages of the ~~last three~~ commits. ~~The other commits are from #106 and #107. I'd still like to wait until the end of the week for any objections to those, though I don't think there will be any.~~

cc @lindig

Resolves #102

@lindig: I have an urge to refactor a bunch of things in the instrumenter and reporter, including dealing with type definitions as you proposed in #100. If that would interfere with your work, I will wait – so let me know :)

Note: I tried several combinations in `InstrumentPpx.faster` to try to get the test `.reference` file diffs minimized, but `Pprintast` seems to have a mind of its own about inserting arbitrary whitespace far away from the affected expressions.