### PR TITLE
Improve testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,18 @@
 sudo: required
-language: c
+
+language: generic
+
+matrix:
+  include:
+    - os: linux
+      env: OCAML_VERSION=4.02
+    - os: linux
+      env: OCAML_VERSION=4.03 COVERALLS=yes
+    - os: linux
+      env: OCAML_VERSION=4.03 BYTECODE_ONLY=yes
+    - os: osx
+      env: OCAML_VERSION=4.02
+    - os: osx
+      env: OCAML_VERSION=4.03
+
 script: bash -e ./src/travis_ci_test.sh
-os:
-  - linux
-  - osx
-env: 
-  - OCAML_VERSION=4.02 OPAM_VERSION=1.2.0 COVERALLS=yes
-  - OCAML_VERSION=4.02 OPAM_VERSION=1.2.0 BYTECODE_ONLY=yes

--- a/tests/test_helpers.mli
+++ b/tests/test_helpers.mli
@@ -92,12 +92,31 @@ val report : ?f:string -> ?r:string -> string -> unit
     If [~f] is supplied, [report] uses the pattern to find [*.out] files. The
     default value is [bisect*.out]. *)
 
-val diff : string -> unit
-(** Runs the command [diff] between the given file and a file [_scratch/output].
-    The file is given relative to [tests/], e.g. ["report/reference.html"]. If
-    there is a difference, fails the current test case, including the difference
-    in the error message. The actual output is also written to the [_preserve]
-    subdirectory. *)
+val diff : ?preserve_as:string -> string -> unit
+(** [diff f] runs the command [diff] between the file [f] and [_scratch/output].
+    [f] is given relative to [tests/], e.g. ["report/reference.html"]. If there
+    is a difference, [diff] fails the current test case, and includes the
+    difference in the error message.
+
+    [_scratch/output] is then copied to the [_preserve] subdirectory, under a
+    matching filename - e.g. ["_preserve/report/reference.html"]. This preserved
+    output can be used to replace [f] if, in fact, the output is correct:
+
+    run
+
+      cp _preserve/some_test_suite/foo.ml.reference some_test_suite/
+
+    or
+
+      cp -r _preserve/* .
+
+    in the [tests/] directory.
+
+    Sometimes, [f] is the name of an intermediate generated file, rather than an
+    original reference file under source control. In this case, [~preserve_as]
+    can be used to override the name under which [_scratch/output] is preserved.
+    If the argument is provided, output is copied to
+    ["_preserve/" ^ preserve_as]. *)
 
 val normalize_source : string -> string -> unit
 (** [normalize_source source normalized] uses [compiler-libs] to parse the file

--- a/tests/test_main.ml
+++ b/tests/test_main.ml
@@ -23,6 +23,7 @@ let tests = "bisect_ppx" >::: [
   Test_report.tests;
   Test_instrument.tests;
   Test_simple_cases.tests;
+  Test_warnings.tests;
   Test_line_number_directive.tests;
   Test_comments.tests;
   Test_exclude.tests;

--- a/tests/warnings/source.ml
+++ b/tests/warnings/source.ml
@@ -1,0 +1,41 @@
+(* Trigger at least one warning to make sure they are on. *)
+let () =
+  let f ?maybe () = ignore maybe in
+  () |> f
+
+type t = A | B | C
+type u = {a : int; b : int; c : int}
+
+(* Triggers (suppressed) warning 4 without -inexhaustive-matching: fragile
+   pattern matching (due to wildcard). *)
+(* Triggers (suppressed) warning 11 without -inexhaustive-matching: unused match
+   case (wildcard). *)
+let f x =
+  match x with
+  | A | B | C -> 42
+
+(* Triggers (suppressed) warning 8 with -inexhaustive-matching: inexhaustive
+   matching. *)
+let g x =
+  match x with
+  | A | B -> 42
+  | C -> 43
+
+(* Triggers a (suppressed) duplicate set of warning 9 (missing record
+   labels). *)
+(* Triggers (suppressed) warning 27: unused variable a. *)
+let h x =
+  match x with
+  | {a} | {a} -> ignore a
+
+(* Triggers (suppressed) warning 26: unused variable x. *)
+let i x =
+  match x with
+  | (A as x) | (B as x) -> ignore x; 42
+  | C -> 43
+
+(* Triggers (suppressed) duplicate warning 28 (wildcard given to constant
+   constructor). *)
+let j x =
+  match x with
+  | A _ | B | C -> ()

--- a/tests/warnings/source.ml.reference
+++ b/tests/warnings/source.ml.reference
@@ -1,0 +1,14 @@
+File "source.ml", line 4, characters 8-9:
+Warning 48: implicit elimination of optional argument ?maybe
+File "source.ml", line 29, characters 4-7:
+Warning 9: the following labels are not bound in this record pattern:
+b, c
+Either bind these labels explicitly or add '; _' to the pattern.
+File "source.ml", line 29, characters 10-13:
+Warning 9: the following labels are not bound in this record pattern:
+b, c
+Either bind these labels explicitly or add '; _' to the pattern.
+File "source.ml", line 29, characters 10-13:
+Warning 12: this sub-pattern is unused.
+File "source.ml", line 41, characters 6-7:
+Warning 28: wildcard pattern given as argument to a constant constructor

--- a/tests/warnings/test_warnings.ml
+++ b/tests/warnings/test_warnings.ml
@@ -1,0 +1,43 @@
+(*
+ * This file is part of Bisect_ppx.
+ * Copyright (C) 2016 Anton Bachin.
+ *
+ * Bisect is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Bisect is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *)
+
+open OUnit2
+open Test_helpers
+
+(* OCaml 4.02 and 4.03 order output of warnings 12 and 28 differently. To get
+   around that, these tests sort the output lines. *)
+let sorted_diff () =
+  run "sort < output.raw > output";
+  run "sort < ../warnings/source.ml.reference > reference";
+  diff ~preserve_as:"warnings/source.ml.reference" "_scratch/reference"
+
+let tests = "warnings" >::: [
+  test "default" begin fun () ->
+    compile
+      ((with_bisect ()) ^ " -w +A") "warnings/source.ml" ~r:"2> output.raw";
+    sorted_diff ()
+  end;
+
+  test "inexhaustive-matching" begin fun () ->
+    compile
+      ((with_bisect_args "-inexhaustive-matching") ^ " -w +A")
+      "warnings/source.ml"
+      ~r:"2> output.raw";
+    sorted_diff ()
+  end
+]


### PR DESCRIPTION
See the attached commit messages. Resolves #94.

The diff commit changes failed test diff output from this:

```
Difference against 'warnings/source.ml.reference':

11,12d10
< File "source.ml", line 29, characters 10-13:
< Warning 12: this sub-pattern is unused.
14a13,14
> File "source.ml", line 29, characters 10-13:
> Warning 12: this sub-pattern is unused.
```

to this:

```
Difference against 'warnings/source.ml.reference':

--- warnings/source.ml.reference
+++ actual output
@@ -8,7 +8,7 @@
 Warning 9: the following labels are not bound in this record pattern:
 b, c
 Either bind these labels explicitly or add '; _' to the pattern.
-File "source.ml", line 29, characters 10-13:
-Warning 12: this sub-pattern is unused.
 File "source.ml", line 41, characters 6-7:
 Warning 28: wildcard pattern given as argument to a constant constructor
+File "source.ml", line 29, characters 10-13:
+Warning 12: this sub-pattern is unused.
```

EDIT: GitHub seems to be displaying the commits in the wrong order. The "absence of warnings" commit is last.