### PR TITLE
Minor changes

### DIFF
--- a/tests/exclude-comments/excluded_clauses.ml
+++ b/tests/exclude-comments/excluded_clauses.ml
@@ -1,0 +1,34 @@
+let test_oneline = function
+  | None -> "included"
+  | Some true when Random.bool () -> (*BISECT-IGNORE*) "ignored"
+  | Some true -> (*BISECT-IGNORE*) "ignored"
+  | Some false when Random.bool () -> (*BISECT-VISIT*) "visited"
+  | Some false -> (*BISECT-VISIT*) "visited"
+
+let test_oneline_multipat = function
+  | None -> "included"
+  | Some 1 | Some 2 | Some 3 -> (*BISECT-IGNORE*) "ignored"
+  | Some 4 | Some 5 | Some 6 -> (*BISECT-VISIT*) "visited"
+  | Some _ -> "included"
+
+let test_oneline_split = function
+  | None -> "included"
+  | Some true when Random.bool () -> (*BISECT-IGNORE*)
+    "ignored"
+  | Some true -> (*BISECT-IGNORE*)
+    "ignored"
+  | Some false when Random.bool () -> (*BISECT-VISIT*)
+    "visited"
+  | Some false -> (*BISECT-VISIT*)
+    "visited"
+
+let test_multiline = function
+  | None -> "included"
+(*BISECT-IGNORE-BEGIN*)
+  | Some 1 | Some 2 | Some 3 ->
+    "ignored"
+(*BISECT-IGNORE-END*)
+(*BISECT-IGNORE-BEGIN*)
+  | Some _ ->
+    "ignored"
+(*BISECT-IGNORE-END*)

--- a/tests/exclude-comments/excluded_clauses.ml.reference
+++ b/tests/exclude-comments/excluded_clauses.ml.reference
@@ -1,0 +1,77 @@
+let ___bisect_mark___excluded_clauses =
+  let points =
+    "\132\149\166\190\000\000\000[\000\000\000\019\000\000\000I\000\000\000I\b\000\000H\000\160SD\160`@\160\001\000\165B\160\001\000\181A\160\001\000\230C\160\001\001,J\160\001\0019E\160\001\001\140F\160\001\001\149G\160\001\001\158H\160\001\001\199I\160\001\001\246O\160\001\002\003K\160\001\002\144M\160\001\002\160L\160\001\002\213N\160\001\003\024Q\160\001\003%P"
+     in
+  let marks = Array.make 18 0  in
+  (Bisect.Runtime.init_with_array "excluded_clauses.ml" marks points;
+   marks.(1) <- 1;
+   marks.(2) <- 1;
+   marks.(3) <- 1;
+   marks.(6) <- 1;
+   marks.(7) <- 1;
+   marks.(8) <- 1;
+   marks.(12) <- 1;
+   marks.(13) <- 1;
+   marks.(14) <- 1);
+  (function
+   | idx ->
+       let curr = marks.(idx)  in
+       marks.(idx) <-
+         (if curr < Pervasives.max_int then Pervasives.succ curr else curr))
+  
+let test_oneline =
+  ___bisect_mark___excluded_clauses 4;
+  (function
+   | None  -> (___bisect_mark___excluded_clauses 0; "included")
+   | Some (true ) when Random.bool () -> "ignored"
+   | Some (true ) -> "ignored"
+   | Some (false ) when ___bisect_mark___excluded_clauses 1; Random.bool ()
+       -> (___bisect_mark___excluded_clauses 2; "visited")
+   | Some (false ) -> (___bisect_mark___excluded_clauses 3; "visited"))
+  
+let test_oneline_multipat =
+  ___bisect_mark___excluded_clauses 10;
+  (function
+   | None  -> (___bisect_mark___excluded_clauses 5; "included")
+   | Some 1|Some 2|Some 3 as ___bisect_matched_value___ ->
+       ((((match ___bisect_matched_value___ with
+           | Some 1 -> ()
+           | Some 2 -> ()
+           | Some 3 -> ()
+           | _ -> ()))
+        [@ocaml.warning "-4-8-9-11-26-27-28"]);
+        "ignored")
+   | Some 4|Some 5|Some 6 as ___bisect_matched_value___ ->
+       ((((match ___bisect_matched_value___ with
+           | Some 4 -> (___bisect_mark___excluded_clauses 6; ())
+           | Some 5 -> (___bisect_mark___excluded_clauses 7; ())
+           | Some 6 -> (___bisect_mark___excluded_clauses 8; ())
+           | _ -> ()))
+        [@ocaml.warning "-4-8-9-11-26-27-28"]);
+        "visited")
+   | Some _ -> (___bisect_mark___excluded_clauses 9; "included"))
+  
+let test_oneline_split =
+  ___bisect_mark___excluded_clauses 15;
+  (function
+   | None  -> (___bisect_mark___excluded_clauses 11; "included")
+   | Some (true ) when Random.bool () -> "ignored"
+   | Some (true ) -> "ignored"
+   | Some (false ) when ___bisect_mark___excluded_clauses 12; Random.bool ()
+       -> (___bisect_mark___excluded_clauses 13; "visited")
+   | Some (false ) -> (___bisect_mark___excluded_clauses 14; "visited"))
+  
+let test_multiline =
+  ___bisect_mark___excluded_clauses 17;
+  (function
+   | None  -> (___bisect_mark___excluded_clauses 16; "included")
+   | Some 1|Some 2|Some 3 as ___bisect_matched_value___ ->
+       ((((match ___bisect_matched_value___ with
+           | Some 1 -> ()
+           | Some 2 -> ()
+           | Some 3 -> ()
+           | _ -> ()))
+        [@ocaml.warning "-4-8-9-11-26-27-28"]);
+        "ignored")
+   | Some _ -> "ignored")
+  

--- a/tests/exclude-comments/test_exclude_comments.ml
+++ b/tests/exclude-comments/test_exclude_comments.ml
@@ -1,0 +1,4 @@
+open Test_helpers
+
+let tests =
+  compile_compare (fun () -> with_bisect_args "") "exclude-comments"

--- a/tests/test_main.ml
+++ b/tests/test_main.ml
@@ -28,6 +28,7 @@ let tests = "bisect_ppx" >::: [
   Test_comments.tests;
   Test_exclude.tests;
   Test_exclude_file.tests;
+  Test_exclude_comments.tests;
   Test_ppx_integration.tests;
   Test_thread_safety.tests;
   Test_ounit_integration.tests;


### PR DESCRIPTION
This PR does not change the tool behavior, but it adds a testsuite for IGNORE/VISIT patterns and their interaction with clause marking, and reorder the instrumented code to make the output readable (I would checked that I got the expected VISIT behavior, which requires looking at the generated code.) Feel free to kill this PR under the "if it ain't broke, don't fix it" rule.