### PR TITLE
Fixes unary operator expected issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,7 @@ INTERFACE_FILES = \
 	$(shell find $1/src -name '*.cmt*')
 
 install: FORCE
-	[ $(DEV_INSTALL) = "" ] || mkdir -p $(DEV_INSTALL_DIR)
+	[ "$(DEV_INSTALL)" = "" ] || mkdir -p $(DEV_INSTALL_DIR)
 	@! ocamlfind query $(INSTALL_NAME) > /dev/null 2> /dev/null || \
 		ocamlfind remove $(INSTALL_FLAGS) $(INSTALL_NAME)
 	@cp $(REWRITER_NATIVE) $(REWRITER) 2> /dev/null || \


### PR DESCRIPTION
When running `make install` the following error occurred:
`/bin/sh: line 0: [: =: unary operator expected`
In makefile we need to put our reference to DEV_INSTALL in double
quotes.