### PR TITLE
Expose functions in runtime.mli to dump counters

### DIFF
--- a/src/library/runtime.ml
+++ b/src/library/runtime.ml
@@ -74,13 +74,23 @@ let file_channel () =
   let channel_opt = ic_opt_loop (next_name ()) in
   channel_opt
 
+let dump_counters_exn channel =
+  let content = Hashtbl.fold (fun k v acc -> (k, v) :: acc) table [] in
+  Common.write_runtime_data channel content
+
+let reset_counters () =
+  Hashtbl.iter (fun _ (marks, _) ->
+      match Array.length marks with
+      | 0 -> ()
+      | n -> Array.(fill marks 0 (n - 1) 0)
+    ) table
+
 let dump () =
   match file_channel () with
   | None -> ()
   | Some channel ->
-      let content = Hashtbl.fold (fun k v acc -> (k, v) :: acc) table [] in
       (try
-        Common.write_runtime_data channel content;
+        dump_counters_exn channel
       with _ ->
         verbose Unable_to_write_file);
       close_out_noerr channel

--- a/src/library/runtime.mli
+++ b/src/library/runtime.mli
@@ -56,3 +56,11 @@ val init_with_array : string -> int array -> string -> unit
     [marks] to store visitation counts. [points] is a serialized
     [Common.point_definition list] giving the locations of all points in the
     file. *)
+
+val dump_counters_exn : out_channel -> unit
+(** [dump_counters_exn channel] dumps the runtime coverage counters
+ * to the specified [channel].
+ * An exception is raised if writing is not successful *)
+
+val reset_counters : unit -> unit
+(** [reset_counters ()] will reset the runtime coverage counters. *)


### PR DESCRIPTION
Beginning of support for https://github.com/aantron/bisect_ppx/issues/122
Not sure whether `dump_counters_exn` should take a channel, or just take a `unit` and return a `string` with the filename (and keep using `file_channel` internally). I'd slightly favour giving more control to the user of bisect_ppx, i.e. the channel param. Thoughts?