### PR TITLE
[report] Provide useful information in case of `input_value` error.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ bisect.odocl
 
 # scratch directory for notes, etc.
 scratch/
+
+# emacs temporary files
+*~

--- a/src/library/common.ml
+++ b/src/library/common.ml
@@ -45,7 +45,8 @@ let try_out_channel bin x f =
 
 (* I/O functions *)
 
-exception Invalid_file of string
+(* filename + reason *)
+exception Invalid_file of string * string
 
 exception Unsupported_version of string
 
@@ -79,7 +80,7 @@ let check_channel channel filename magic check_digest =
       else
         file_version
     else
-      raise (Invalid_file filename) in
+      raise (Invalid_file (filename, "bad magic number")) in
   (match check_digest with
   | Some file ->
       let file_digest : string = input_value channel in
@@ -105,7 +106,9 @@ let read_runtime_data' filename =
       match version with
       | 2, 0 ->
           let file_content : (string * (int array * string)) array =
-            input_value channel in
+            (try input_value channel
+             with | e -> raise (Invalid_file (filename, "exception reading data: " ^ Printexc.to_string e))
+            ) in
           Array.to_list file_content
       | _ -> assert false)
 

--- a/src/library/common.mli
+++ b/src/library/common.mli
@@ -53,9 +53,10 @@ val try_out_channel : bool -> string -> (out_channel -> 'a) -> 'a
 
 (** {6 I/O functions} *)
 
-exception Invalid_file of string
-(** Exception to be raised when a read file does not conform to the Bisect
-    format. The parameter is the name of the incriminated file. *)
+exception Invalid_file of string * string
+(** Exception to be raised when a read file does not conform to the
+    Bisect format. The parameter is the name of the incriminated file
+    and the reason of the error. *)
 
 exception Unsupported_version of string
 (** Exception to be raised when a read file has a format whose version is

--- a/src/report/report.ml
+++ b/src/report/report.ml
@@ -91,8 +91,8 @@ let () =
   | Unix.Unix_error (e, _, _) ->
       Printf.eprintf " *** system error: %s\n" (Unix.error_message e);
       exit 1
-  | Common.Invalid_file s ->
-      Printf.eprintf " *** invalid file: '%s'\n" s;
+  | Common.Invalid_file (f, reason) ->
+      Printf.eprintf " *** invalid file: '%s' error: \"%s\"\n" f reason;
       exit 1
   | Common.Unsupported_version s ->
       Printf.eprintf " *** unsupported file version: '%s'\n" s;


### PR DESCRIPTION
Thanks for bisect_ppx. In some cases when my build is interrupted, I get some corrupted files but, I cannot determine which one is the bad one as the exception lacks information. This patch adds the bad filename to error printing.