### PR TITLE
Uses source filenames for the html-report urls

### DIFF
--- a/src/report/report_html.ml
+++ b/src/report/report_html.ml
@@ -696,8 +696,7 @@ let output_html
 let output verbose dir tab_size title resolver data points =
   let files = Hashtbl.fold
       (fun in_file visited acc ->
-        let l = List.length acc in
-        let basename = Printf.sprintf "file%04d" l in
+        let basename = Filename.basename in_file in
         let out_file = (Filename.concat dir basename) ^ ".html" in
         let maybe_stats =
           output_html verbose tab_size title in_file out_file resolver

--- a/src/report/report_html.ml
+++ b/src/report/report_html.ml
@@ -694,7 +694,8 @@ let output_html
     Some stats
 
 let output verbose dir tab_size title resolver data points =
-  let files = Hashtbl.fold
+  let files =
+    Hashtbl.fold
       (fun in_file visited acc ->
         let basename = Filename.basename in_file in
         let out_file = (Filename.concat dir basename) ^ ".html" in

--- a/test/src/test_report.ml
+++ b/test/src/test_report.ml
@@ -26,7 +26,7 @@ let tests = "report" >::: [
 
   test "html" (fun () ->
     report "-html html_dir";
-    run "grep -v 'id=\"footer\"' html_dir/file0000.html > output";
+    run "grep -v 'id=\"footer\"' html_dir/source.ml.html > output";
     diff "fixtures/report/reference.html");
 
   test "text" (fun () ->


### PR DESCRIPTION
Summary:
Modifies the .html files output by bisect-ppx-report to use the source
filename rather than an arbitrary number. For example:
`file0001.html` becomes `source.ml.html`.
- fixes #124