### PR TITLE
Restore new Ocamlbuild instructions and add Jbuilder instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ to run that script, then refresh your browser.
    You can also install [without OPAM][without-opam].
 
 2. When compiling for testing, include Bisect_ppx. Instructions are also
-   available [for Ocamlbuild][ocamlbuild] and [for OASIS][oasis].
+   available for [Ocamlbuild][ocamlbuild], [OASIS][oasis] and
+   [Jbuilder][jbuilder].
 
         ocamlfind c -package bisect_ppx -c my_code.ml
         ocamlfind c -c my_tests.ml
@@ -64,6 +65,7 @@ See also the [advanced usage][advanced].
 [without-opam]: https://github.com/aantron/bisect_ppx/blob/master/doc/advanced.md#WithoutOPAM
 [ocamlbuild]:   https://github.com/aantron/bisect_ppx/blob/master/doc/advanced.md#Ocamlbuild
 [oasis]:        https://github.com/aantron/bisect_ppx/blob/master/doc/advanced.md#OASIS
+[jbuilder]:     https://github.com/aantron/bisect_ppx/blob/master/doc/advanced.md#Jbuilder
 [ocveralls]:    https://github.com/sagotch/ocveralls
 [advanced]:     https://github.com/aantron/bisect_ppx/blob/master/doc/advanced.md
 

--- a/doc/advanced.md
+++ b/doc/advanced.md
@@ -58,6 +58,10 @@ customize and incorporate it, and/or include it in releases.
 
 It is used like this:
 
+1. Install the plugin:
+
+        opam install bisect_ppx-ocamlbuild
+
 1. Create a `myocamlbuild.ml` file in your project root, with the following
    contents:
 
@@ -66,7 +70,7 @@ It is used like this:
 
    If you already have `myocamlbuild.ml`, you just need to call
    `Bisect_ppx_plugin.handle_coverage ()` somewhere in it.
-2. Add `-use-ocamlfind -plugin-tag 'package(bisect_ppx.ocamlbuild)'` to your
+2. Add `-use-ocamlfind -plugin-tag 'package(bisect_ppx-ocamlbuild)'` to your
    Ocamlbuild invocation.
 3. <a id="Tagging"></a> Now, you have a new tag available, called `coverage`.
    Make your `_tags` file look something like this:
@@ -81,11 +85,11 @@ It is used like this:
 
         # For tests
         BISECT_COVERAGE=YES ocamlbuild -use-ocamlfind \
-            -plugin-tag 'package(bisect_ppx.ocamlbuild)' tests/test.native --
+            -plugin-tag 'package(bisect_ppx-ocamlbuild)' tests/test.native --
 
         # For release
         ocamlbuild -use-ocamlfind \
-            -plugin-tag 'package(bisect_ppx.ocamlbuild)' src/my_project.native
+            -plugin-tag 'package(bisect_ppx-ocamlbuild)' src/my_project.native
 
 If you don't want to make Bisect_ppx a hard build dependency just for the
 `coverage` tag, you can work the [contents][plugin-code] of `Bisect_ppx_plugin`
@@ -97,12 +101,16 @@ directly into your `myocamlbuild.ml`. Use them to replace the call to
 
 Since OASIS uses Ocamlbuild, the instructions are similar:
 
+1. Install the plugin:
+
+        opam install bisect_ppx-ocamlbuild
+
 1. At the top of your `_oasis` file are the *package fields*, such as the name
    and version. Add these:
 
         OCamlVersion:           >= 4.01
         AlphaFeatures:          ocamlbuild_more_args
-        XOCamlbuildPluginTags:  package(bisect_ppx.ocamlbuild)
+        XOCamlbuildPluginTags:  package(bisect_ppx-ocamlbuild)
 
    Then, run `oasis setup`.
 2. You should have a `myocamlbuild.ml` file in your project root. Near the


### PR DESCRIPTION
The first commit undoes the temporary reversion done in #150, by restoring mention of the new `bisect_ppx-ocamlbuild` package. The second commit explains how to use Bisect_ppx with Jbuilder. It is the documentation component of #153, and prompted by #149.

The new docs can be previewed in the branch at: https://github.com/aantron/bisect_ppx/blob/updated-instructions/doc/advanced.md.

Resolves #150.