### PR TITLE
CSV report with per-line coverage info

### DIFF
--- a/src/report/report.ml
+++ b/src/report/report.ml
@@ -7,6 +7,7 @@
 type output_kind =
   | Html_output of string
   | Csv_output of string
+  | Csv_line_output of string
   | Text_output of string
   | Dump_output of string
 
@@ -74,6 +75,10 @@ let options = Arg.align [
   ("-csv",
    Arg.String (fun s -> add_output (Csv_output s)),
    "<file>  Output CSV report to <file>");
+
+  ("-csv-line",
+   Arg.String (fun s -> add_output (Csv_line_output s)),
+   "<file>  Output line coverage CSV report to <file>");
 
   ("-separator",
    Arg.Set_string csv_separator,
@@ -173,6 +178,9 @@ let main () =
           search_in_path data points
     | Csv_output file ->
         generic_output file (Report_csv.make !csv_separator)
+    | Csv_line_output file ->
+        Report_csv_line.output verbose file !csv_separator search_in_path data
+          points
     | Text_output file ->
         generic_output file (Report_text.make !summary_only)
     | Dump_output file ->

--- a/src/report/report_csv_line.ml
+++ b/src/report/report_csv_line.ml
@@ -1,0 +1,71 @@
+module R = Report_utils
+
+let output_lines verbose csv_separator in_file out_channel resolver visited
+    points =
+  verbose (Printf.sprintf "Processing file '%s'..." in_file);
+  match resolver in_file with
+  | None -> verbose "... file not found"
+  | Some resolved_in_file ->
+    let cmp_content = Hashtbl.find points in_file
+                      |> Bisect.Common.read_points' in
+    verbose (Printf.sprintf "... file has %d points" (List.length cmp_content));
+    let points =
+      let len = Array.length visited in
+      ref (List.map
+          (fun point ->
+            let is_visited = point.Bisect.Common.identifier < len in
+            (point.Bisect.Common.offset, is_visited))
+          cmp_content) in
+    let in_channel = open_in resolved_in_file in
+    (try
+      let lines, _line_count =
+        let rec read number acc =
+          try
+            ignore (input_line in_channel);
+            let end_offset = pos_in in_channel in
+            let before, after =
+              R.split (fun (offset, _) -> offset < end_offset)
+                !points in
+            points := after;
+            let is_visited =
+              List.fold_left (fun acc (_, is_visited) -> acc || is_visited)
+                false before
+            in
+            let is_unvisited =
+              List.fold_left (fun acc (_, is_visited) -> acc || not is_visited)
+                false before
+            in
+            read (number + 1) ((number, is_visited, is_unvisited) :: acc)
+          with End_of_file -> List.rev acc, number - 1
+        in
+        read 1 []
+      in
+      List.iter (fun (line_num, visited, unvisited) ->
+        [ Printf.sprintf "\"%s\"" resolved_in_file
+        ; string_of_int line_num
+        ; string_of_bool visited
+        ; string_of_bool unvisited ]
+        |> String.concat csv_separator
+        |> Printf.sprintf "%s\n"
+        |> output_string out_channel)
+        lines
+    with e ->
+      close_in_noerr in_channel;
+      raise e);
+    close_in_noerr in_channel
+
+let output verbose out_file csv_separator resolver data points =
+  let out_channel = open_out out_file in
+  (try
+    let header = [ "file name" ; "line number" ; "visited" ; "unvisited" ]
+                 |> String.concat csv_separator
+                 |> Printf.sprintf "%s\n" in
+    output_string out_channel header;
+    Hashtbl.iter (fun in_file visited ->
+      output_lines verbose csv_separator in_file out_channel resolver visited
+        points)
+      data
+  with e ->
+    close_out_noerr out_channel;
+    raise e);
+  close_out_noerr out_channel;

--- a/src/report/report_csv_line.mli
+++ b/src/report/report_csv_line.mli
@@ -1,0 +1,20 @@
+(* This Source Code Form is subject to the terms of the Mozilla Public License,
+   v. 2.0. If a copy of the MPL was not distributed with this file, You can
+   obtain one at http://mozilla.org/MPL/2.0/. *)
+
+(** This module defines a CSV reporter which gives info on a line-by-line
+   basis rather than by file offset. This is useful when integrating with
+   external line coverage reporters like Phabricator. *)
+
+val output :
+  (string -> unit) -> string -> string -> (string -> string option) ->
+  (string, int array) Hashtbl.t -> (string, string) Hashtbl.t ->
+  unit
+(** [output verbose out_file csv_separator resolver data points] writes a CSV
+    to [out_file] where each line is the file name, a line number, whether there
+    were any visited points on the line, and whether there were any unvisited
+    points on the line.
+
+    [verbose] is used for verbose output, [csv_separator] determines the CSV
+    separator, and [resolver] associates actual paths to given filenames.
+    [points] gives the marshalled locations of the points in the file. *)


### PR DESCRIPTION
A lot of tools don't support coverage by file offset, so this is a new report that reports coverage by line.

Due to the fact that a line can have both covered and uncovered parts, this shows both pieces of info and lets downstream tools figure out what to do with that.

As an example of where this would be useful, [Phabricator's coverage reports](https://secure.phabricator.com/book/phabricator/article/arcanist_coverage/) only understands per-line "covered", "uncovered", "not executable" and "unreachable. With this new report, we can show any line with an unvisited point as "uncovered", any line with a visited point that doesn't also have a visited point as "covered", and anything else as "not executable".