### PR TITLE
WIP: s-expression outputter, and color-coverage emacs mode

### DIFF
--- a/src/report/color-coverage.el
+++ b/src/report/color-coverage.el
@@ -1,0 +1,51 @@
+(defvar-local color-coverage-overlays '() "All coverage overlays in the current buffer")
+
+(defun color-coverage-remove ()
+  "Remove all coverage overlays"
+  (mapc #'delete-overlay color-coverage-overlays)
+  (setq color-coverage-overlays '())
+  (setq global-mode-string nil))
+
+(defun coverage-color-region (offset end-offset count)
+  "Highlight using an overlay from OFFSET to
+  min (END-OFFSET, end of line, end of file) using count as indicator."
+  (save-restriction
+    (widen)
+    (goto-char offset)
+    (let* ((end-off (min (line-end-position) end-offset))
+           (overlay (make-overlay offset end-off))
+           (color (if (= count 0) '(:foreground "red") '(:foreground "darkgreen"))))
+      (overlay-put overlay 'face color)
+;      (message "coloring at %d %d with %s in %s" offset count color (buffer-name))
+      (push overlay color-coverage-overlays))))
+
+(defun is-buffer (name)
+  (string= (file-name-nondirectory name) (buffer-name)))
+
+(defun coverage-info (name x)
+  (if (is-buffer name)
+      (save-excursion
+        (if (not (null x))
+            (let* ((percent (car (cdr (car x))))
+                   (data (cdr x)))
+              (setq global-mode-string percent)
+              (let* ((first (car data))
+                     (offs (car first))
+                     (count (car (cdr first)))
+                     (marks (cdr data)))
+                (while (not (null marks))
+                  (let* ((mark (car marks))
+                         (end-off (car mark))
+                         (next-count (car (cdr mark))))
+                    (coverage-color-region offs end-off count)
+                    (setq offs end-off)
+                    (setq count next-count)
+                    (setq marks (cdr marks))))
+                (coverage-color-region offs (+ 100 offs) count)))))))
+
+(defun color-coverage (file)
+  "Colorize with coverage information"
+  (color-coverage-remove)
+  (load-file file))
+
+(provide 'color-coverage)

--- a/src/report/report.ml
+++ b/src/report/report.ml
@@ -10,6 +10,7 @@ type output_kind =
   | Text_output of string
   | Dump_output of string
   | Coveralls_output of string
+  | Sexp_output of string
 
 let report_outputs = ref []
 
@@ -81,6 +82,10 @@ let options = Arg.align [
   ("-csv",
    Arg.String (fun s -> add_output (Csv_output s)),
    "<file>  Output CSV report to <file>");
+
+  ("-sexp",
+   Arg.String (fun s -> add_output (Sexp_output s)),
+   "<file>  Output s-expression reports to <file>");
 
   ("-separator",
    Arg.Set_string csv_separator,
@@ -199,7 +204,9 @@ let main () =
     | Text_output file ->
         generic_output file (Report_text.make !summary_only)
     | Dump_output file ->
-        generic_output file (Report_dump.make ())
+      generic_output file (Report_dump.make ())
+    | Sexp_output file ->
+      generic_output file (Report_sexp.make ())
     | Coveralls_output file ->
         Report_coveralls.output verbose file
           !service_name !service_job_id !repo_token

--- a/src/report/report_sexp.ml
+++ b/src/report/report_sexp.ml
@@ -1,0 +1,21 @@
+
+let make () =
+  object (self)
+    method header = ""
+    method footer = ""
+    method summary _ = ""
+    (*      Printf.sprintf "(percent %s)(total %d)" (self#sum s) s.Report_utils.total *)
+    method file_header f = Printf.sprintf "(coverage-info %S '(" f
+    method file_footer _ = "))\n"
+    method file_summary s = Printf.sprintf "(percent %S)" (self#sum s)
+    method point offset count = Printf.sprintf "(%d %d)" offset count
+    method private sum s =
+      let numbers x y =
+        if y > 0 then
+          let p = ((float_of_int x) *. 100.) /. (float_of_int y) in
+          Printf.sprintf "%.2f%% covered" p
+        else
+          "no"
+      in
+      Report_utils.(numbers s.visited s.total)
+  end


### PR DESCRIPTION
I was sick of OCaml and needed to write some Emacs Lisp again... now it's all colourful:
![color-coverage](https://user-images.githubusercontent.com/228456/56854281-30d51e80-6934-11e9-87b6-a5e0f837428e.png)

The workflow atm:
- `dune runtest` (with instrumented bisect_ppx)
- `bisect-ppx-report -text - _build/default/test/bisect*.out -sexp /tmp/cov.sexp`
- in Emacs: load `color-coverage.el`, `M-x eval-buffer`, back to your source file `M-x eval-expression` `(color-coverage "/tmp/cov.sexp")`
- another `(color-coverage)` invocation will first clear the highlightinh
- `M-x evaluate-expression` `(color-coverage-remove)` removes the highlighting (could be hooked to when the buffer is modified)

Now you get highlights: for each point from start till `min (next offset) (end-of-line)` you get `darkgreen` for `count <> 0` and `red` for `count = 0`. You also see a "NN% covered" in the modeline. :)

of course, tooling and workflow can improve, but this is a first cut to get rid of my webbrowser when evaluating coverage reports. let me know what you think :)