### PR TITLE
randomize output file name

### DIFF
--- a/src/runtime/runtime.ml
+++ b/src/runtime/runtime.ml
@@ -52,22 +52,23 @@ let table : (string, int array * string) Hashtbl.t Lazy.t =
 
 let file_channel () =
   let base_name = full_path (env_to_fname "BISECT_FILE" "bisect") in
-  let rec create_file numeric_suffix =
+  let rec create_file () =
+    let numeric_suffix = abs (Random.int 1000000000) in
     let filename =
-      Printf.sprintf "%s%04d.%s" base_name numeric_suffix Extension.value in
+      Printf.sprintf "%s%09d.%s" base_name numeric_suffix Extension.value in
     try
       let fd = Unix.(openfile filename [O_WRONLY; O_CREAT; O_EXCL] 0o644) in
       let channel = Unix.out_channel_of_descr fd in
       Some channel
     with
-    | Unix.Unix_error (Unix.EEXIST, _, _) -> create_file @@ abs @@ Random.int 1000000000
+    | Unix.Unix_error (Unix.EEXIST, _, _) -> create_file ()
     | Unix.Unix_error (code, _, _) ->
       let detail = Printf.sprintf "%s: %s" (Unix.error_message code) filename in
       verbose Unable_to_create_file;
       verbose (String detail);
       None
   in
-  create_file 1
+  create_file ()
 
 let dump_counters_exn channel =
   let content =

--- a/src/runtime/runtime.ml
+++ b/src/runtime/runtime.ml
@@ -60,7 +60,7 @@ let file_channel () =
       let channel = Unix.out_channel_of_descr fd in
       Some channel
     with
-    | Unix.Unix_error (Unix.EEXIST, _, _) -> create_file (numeric_suffix + 1)
+    | Unix.Unix_error (Unix.EEXIST, _, _) -> create_file @@ abs @@ Random.int 1000000000
     | Unix.Unix_error (code, _, _) ->
       let detail = Printf.sprintf "%s: %s" (Unix.error_message code) filename in
       verbose Unable_to_create_file;

--- a/test/usage/dune-conditional/Makefile
+++ b/test/usage/dune-conditional/Makefile
@@ -1,11 +1,11 @@
 .PHONY : test
 test : clean
 	dune exec ./source.exe
-	! test -f bisect0001.out
+	! test -f bisect*.out
 	dune clean
 	BISECT_ENABLE=YES dune exec ./source.exe
 	ls -l _build
-	test -f bisect0001.out
+	test -f bisect*.out
 
 .PHONY : clean
 clean :

--- a/test/usage/dune-linkall/Makefile
+++ b/test/usage/dune-linkall/Makefile
@@ -1,7 +1,7 @@
 .PHONY : test
 test :
 	dune exec ./source.exe
-	! test -f bisect0001.out
+	! test -f bisect*.out
 
 .PHONY : clean
 clean :

--- a/test/usage/dune-unconditional/Makefile
+++ b/test/usage/dune-unconditional/Makefile
@@ -1,7 +1,7 @@
 .PHONY : test
 test : clean
 	dune exec ./source.exe
-	test -f bisect0001.out
+	test -f bisect*.out
 
 .PHONY : clean
 clean :

--- a/test/usage/ocamlbuild/Makefile
+++ b/test/usage/ocamlbuild/Makefile
@@ -9,9 +9,9 @@ test : clean
 	! test -f bisect0001.out
 	@# If the PPX option is passed correctly, there will be no output.
 	BISECT_COVERAGE=YES $(OCAMLBUILD) $(CONDITIONAL) source.byte --
-	! test -f bisect0001.out
+	! test -f bisect*.out
 	BISECT_COVERAGE=YES $(OCAMLBUILD) source.byte --
-	test -f bisect0001.out
+	test -f bisect*.out
 
 .PHONY : clean
 clean :

--- a/test/usage/ocamlfind/Makefile
+++ b/test/usage/ocamlfind/Makefile
@@ -4,14 +4,14 @@ BISECT := -package bisect_ppx -ppxopt bisect_ppx,-conditional
 test : clean
 	ocamlfind opt -linkpkg source.ml
 	./a.out
-	! test -f bisect0001.out
+	! test -f bisect*.out
 	@# If the PPX option is passed correctly, there will be no output.
 	ocamlfind opt -linkpkg $(BISECT) source.ml
 	./a.out
-	! test -f bisect0001.out
+	! test -f bisect*.out
 	BISECT_ENABLE=YES ocamlfind opt -linkpkg $(BISECT) source.ml
 	./a.out
-	test -f bisect0001.out
+	test -f bisect*.out
 
 .PHONY : clean
 clean :


### PR DESCRIPTION
Instead of incrementally trying file names from `bisect_0001.out` and up, randomize the number suffix.  This is intended to keep the 10,000th consecutive run of a program from looking for 9,999 files before writing, with motivation further described in #193 .