### PR TITLE
Control instrumentation using AST attributes

### DIFF
--- a/doc/advanced.md
+++ b/doc/advanced.md
@@ -13,6 +13,7 @@ them after `bisect_ppx` in the `pps` list.
   - [With Ocamlbuild](#Ocamlbuild)
   - [With OASIS](#OASIS)
 - [Excluding code from coverage](#Excluding)
+  - [Expressions and structure items](#ExcludingExpressions)
   - [Individual lines and line ranges](#ExcludingLines)
   - [Files and top-level values](#ExcludingValues)
 - [Environment variables](#EnvironmentVariables)
@@ -209,8 +210,23 @@ The easiest way to exclude a file from coverage is simply not to build it with
 need finer control. There are several ways to disable coverage analysis for
 portions of code.
 
+<a id="ExcludingExpressions"></a>
+#### Expressions and structure items
+
+You can tag expressions with `[@coverage off]`, and neither they, nor their
+subexpressions, will be instrumented by Bisect_ppx.
+
+Likewise, you can tag module-level `let`-declarations with `[@@coverage off]`,
+and they won't be instrumented.
+
+Finally, you can turn off instrumentation for blocks of declarations inside a
+module with `[@@@coverage off]` and `[@@@coverage on]`.
+
 <a id="ExcludingLines"></a>
 #### Individual lines and line ranges
+
+*Note: this method is deprecated and will be removed; use the approach
+described above in "Expressions and structure items."*
 
 If a comment `(*BISECT-IGNORE*)` is found on a line, that line is excluded from
 coverage analysis. If `(*BISECT-VISIT*)` is found, all points on that line are

--- a/src/ppx/instrument.ml
+++ b/src/ppx/instrument.ml
@@ -63,26 +63,16 @@ sig
 end =
 struct
   let recognize loc name payload =
-    let is_coverage_attribute =
-      name = "coverage" ||
-      (String.length name >= String.length "coverage." &&
-      String.sub name 0 (String.length "coverage.") = "coverage.")
-    in
-    if not is_coverage_attribute then
+    if name <> "coverage" then
       `None
-    else begin
-      if payload <> Parsetree.PStr [] then
-        Location.raise_errorf
-          ~loc "Coverage attribute should not have a payload.";
-
-      match name with
-      | "coverage.off" ->
+    else
+      match payload with
+      | Parsetree.PStr [%str off] ->
         `Off
-      | "coverage.on" ->
+      | PStr [%str on] ->
         `On
       | _ ->
-        Location.raise_errorf ~loc "Unrecognized coverage attribute %s." name
-    end
+        Location.raise_errorf ~loc "Bad payload in coverage attribute."
 
   let has_off_attribute attributes =
     (* Don't short-circuit the search, because we want to error-check all

--- a/test/unit/fixtures/attributes/expression.ml
+++ b/test/unit/fixtures/attributes/expression.ml
@@ -1,11 +1,11 @@
 let () =
   if true then
-    ignore 1 [@coverage.off]
+    ignore 1 [@coverage off]
   else
     ignore 2;;
 
 ignore 3;;
 
-ignore 4 [@coverage.off];;
+ignore 4 [@coverage off];;
 
-(ignore (if true then 5 else 6)) [@coverage.off];;
+(ignore (if true then 5 else 6)) [@coverage off];;

--- a/test/unit/fixtures/attributes/expression.ml
+++ b/test/unit/fixtures/attributes/expression.ml
@@ -1,0 +1,11 @@
+let () =
+  if true then
+    ignore 1 [@coverage.off]
+  else
+    ignore 2;;
+
+ignore 3;;
+
+ignore 4 [@coverage.off];;
+
+(ignore (if true then 5 else 6)) [@coverage.off];;

--- a/test/unit/fixtures/attributes/expression.reference.ml
+++ b/test/unit/fixtures/attributes/expression.reference.ml
@@ -12,8 +12,8 @@ open Bisect_visit___expression___ml
 let () =
   ___bisect_visit___ 1;
   if true
-  then ((ignore 1)[@coverage.off ])
+  then ((ignore 1)[@coverage off])
   else (___bisect_visit___ 0; ignore 2)
 ;;___bisect_visit___ 2; ignore 3
-;;((ignore 4)[@coverage.off ])
-;;((ignore (if true then 5 else 6))[@coverage.off ])
+;;((ignore 4)[@coverage off])
+;;((ignore (if true then 5 else 6))[@coverage off])

--- a/test/unit/fixtures/attributes/expression.reference.ml
+++ b/test/unit/fixtures/attributes/expression.reference.ml
@@ -1,0 +1,19 @@
+module Bisect_visit___expression___ml =
+  struct
+    let ___bisect_visit___ =
+      let point_definitions =
+        "\132\149\166\190\000\000\000\012\000\000\000\004\000\000\000\r\000\000\000\r\176\160KA\160\000@@\160\000LB" in
+      let `Staged cb =
+        Bisect.Runtime.register_file "expression.ml" ~point_count:3
+          ~point_definitions in
+      cb
+  end
+open Bisect_visit___expression___ml
+let () =
+  ___bisect_visit___ 1;
+  if true
+  then ((ignore 1)[@coverage.off ])
+  else (___bisect_visit___ 0; ignore 2)
+;;___bisect_visit___ 2; ignore 3
+;;((ignore 4)[@coverage.off ])
+;;((ignore (if true then 5 else 6))[@coverage.off ])

--- a/test/unit/fixtures/attributes/floating.ml
+++ b/test/unit/fixtures/attributes/floating.ml
@@ -1,6 +1,6 @@
 let instrumented = ()
 
-[@@@coverage.off]
+[@@@coverage off]
 
 let not_instrumented = ()
 
@@ -9,7 +9,7 @@ struct
   let also_not_instrumented = ()
 end
 
-[@@@coverage.on]
+[@@@coverage on]
 
 let instrumented_again = ()
 
@@ -17,7 +17,7 @@ module Nested_2 =
 struct
   let instrumented_3 = ()
 
-  [@@@coverage.off]
+  [@@@coverage off]
 
   let not_instrumented_3 = ()
 end

--- a/test/unit/fixtures/attributes/floating.ml
+++ b/test/unit/fixtures/attributes/floating.ml
@@ -1,0 +1,25 @@
+let instrumented = ()
+
+[@@@coverage.off]
+
+let not_instrumented = ()
+
+module Nested_1 =
+struct
+  let also_not_instrumented = ()
+end
+
+[@@@coverage.on]
+
+let instrumented_again = ()
+
+module Nested_2 =
+struct
+  let instrumented_3 = ()
+
+  [@@@coverage.off]
+
+  let not_instrumented_3 = ()
+end
+
+let instrumented_4 = ()

--- a/test/unit/fixtures/attributes/floating.reference.ml
+++ b/test/unit/fixtures/attributes/floating.reference.ml
@@ -10,15 +10,15 @@ module Bisect_visit___floating___ml =
   end
 open Bisect_visit___floating___ml
 let instrumented = ___bisect_visit___ 0; ()
-[@@@coverage.off ]
+[@@@coverage off]
 let not_instrumented = ()
 module Nested_1 = struct let also_not_instrumented = () end
-[@@@coverage.on ]
+[@@@coverage on]
 let instrumented_again = ___bisect_visit___ 1; ()
 module Nested_2 =
   struct
     let instrumented_3 = ___bisect_visit___ 2; ()
-    [@@@coverage.off ]
+    [@@@coverage off]
     let not_instrumented_3 = ()
   end
 let instrumented_4 = ___bisect_visit___ 3; ()

--- a/test/unit/fixtures/attributes/floating.reference.ml
+++ b/test/unit/fixtures/attributes/floating.reference.ml
@@ -1,0 +1,24 @@
+module Bisect_visit___floating___ml =
+  struct
+    let ___bisect_visit___ =
+      let point_definitions =
+        "\132\149\166\190\000\000\000\019\000\000\000\005\000\000\000\017\000\000\000\017\192\160S@\160\001\000\175A\160\001\000\227B\160\001\0014C" in
+      let `Staged cb =
+        Bisect.Runtime.register_file "floating.ml" ~point_count:4
+          ~point_definitions in
+      cb
+  end
+open Bisect_visit___floating___ml
+let instrumented = ___bisect_visit___ 0; ()
+[@@@coverage.off ]
+let not_instrumented = ()
+module Nested_1 = struct let also_not_instrumented = () end
+[@@@coverage.on ]
+let instrumented_again = ___bisect_visit___ 1; ()
+module Nested_2 =
+  struct
+    let instrumented_3 = ___bisect_visit___ 2; ()
+    [@@@coverage.off ]
+    let not_instrumented_3 = ()
+  end
+let instrumented_4 = ___bisect_visit___ 3; ()

--- a/test/unit/fixtures/attributes/include.ml
+++ b/test/unit/fixtures/attributes/include.ml
@@ -1,0 +1,10 @@
+module Foo =
+struct
+  let instrumented = ()
+
+  [@@@coverage.off]
+  let not_instrumented = ()
+end
+
+[@@@coverage.off]
+include Foo

--- a/test/unit/fixtures/attributes/include.ml
+++ b/test/unit/fixtures/attributes/include.ml
@@ -2,9 +2,9 @@ module Foo =
 struct
   let instrumented = ()
 
-  [@@@coverage.off]
+  [@@@coverage off]
   let not_instrumented = ()
 end
 
-[@@@coverage.off]
+[@@@coverage off]
 include Foo

--- a/test/unit/fixtures/attributes/include.reference.ml
+++ b/test/unit/fixtures/attributes/include.reference.ml
@@ -12,8 +12,8 @@ open Bisect_visit___include___ml
 module Foo =
   struct
     let instrumented = ___bisect_visit___ 0; ()
-    [@@@coverage.off ]
+    [@@@coverage off]
     let not_instrumented = ()
   end
-[@@@coverage.off ]
+[@@@coverage off]
 include Foo

--- a/test/unit/fixtures/attributes/include.reference.ml
+++ b/test/unit/fixtures/attributes/include.reference.ml
@@ -1,0 +1,19 @@
+module Bisect_visit___include___ml =
+  struct
+    let ___bisect_visit___ =
+      let point_definitions =
+        "\132\149\166\190\000\000\000\004\000\000\000\002\000\000\000\005\000\000\000\005\144\160i@" in
+      let `Staged cb =
+        Bisect.Runtime.register_file "include.ml" ~point_count:1
+          ~point_definitions in
+      cb
+  end
+open Bisect_visit___include___ml
+module Foo =
+  struct
+    let instrumented = ___bisect_visit___ 0; ()
+    [@@@coverage.off ]
+    let not_instrumented = ()
+  end
+[@@@coverage.off ]
+include Foo

--- a/test/unit/fixtures/attributes/let.ml
+++ b/test/unit/fixtures/attributes/let.ml
@@ -1,0 +1,14 @@
+let instrumented = ()
+
+let not_instrumented = ()
+  [@@coverage.off]
+
+let instrumented_again = ()
+
+let instrumented_3 = ()
+and not_instrumented_2 = ()
+  [@@coverage.off]
+
+let not_instrumented_3 = ()
+  [@@coverage.off]
+and instrumented_4 = ()

--- a/test/unit/fixtures/attributes/let.ml
+++ b/test/unit/fixtures/attributes/let.ml
@@ -1,14 +1,14 @@
 let instrumented = ()
 
 let not_instrumented = ()
-  [@@coverage.off]
+  [@@coverage off]
 
 let instrumented_again = ()
 
 let instrumented_3 = ()
 and not_instrumented_2 = ()
-  [@@coverage.off]
+  [@@coverage off]
 
 let not_instrumented_3 = ()
-  [@@coverage.off]
+  [@@coverage off]
 and instrumented_4 = ()

--- a/test/unit/fixtures/attributes/let.reference.ml
+++ b/test/unit/fixtures/attributes/let.reference.ml
@@ -1,0 +1,18 @@
+module Bisect_visit___let___ml =
+  struct
+    let ___bisect_visit___ =
+      let point_definitions =
+        "\132\149\166\190\000\000\000\017\000\000\000\005\000\000\000\017\000\000\000\017\192\160S@\160\000^A\160\000wB\160\001\000\238C" in
+      let `Staged cb =
+        Bisect.Runtime.register_file "let.ml" ~point_count:4
+          ~point_definitions in
+      cb
+  end
+open Bisect_visit___let___ml
+let instrumented = ___bisect_visit___ 0; ()
+let not_instrumented = ()[@@coverage.off ]
+let instrumented_again = ___bisect_visit___ 1; ()
+let instrumented_3 = ___bisect_visit___ 2; ()
+and not_instrumented_2 = ()[@@coverage.off ]
+let not_instrumented_3 = ()[@@coverage.off ]
+and instrumented_4 = ___bisect_visit___ 3; ()

--- a/test/unit/fixtures/attributes/let.reference.ml
+++ b/test/unit/fixtures/attributes/let.reference.ml
@@ -10,9 +10,9 @@ module Bisect_visit___let___ml =
   end
 open Bisect_visit___let___ml
 let instrumented = ___bisect_visit___ 0; ()
-let not_instrumented = ()[@@coverage.off ]
+let not_instrumented = ()[@@coverage off]
 let instrumented_again = ___bisect_visit___ 1; ()
 let instrumented_3 = ___bisect_visit___ 2; ()
-and not_instrumented_2 = ()[@@coverage.off ]
-let not_instrumented_3 = ()[@@coverage.off ]
+and not_instrumented_2 = ()[@@coverage off]
+let not_instrumented_3 = ()[@@coverage off]
 and instrumented_4 = ___bisect_visit___ 3; ()

--- a/test/unit/test_attributes.ml
+++ b/test/unit/test_attributes.ml
@@ -1,0 +1,10 @@
+(* This Source Code Form is subject to the terms of the Mozilla Public License,
+   v. 2.0. If a copy of the MPL was not distributed with this file, You can
+   obtain one at http://mozilla.org/MPL/2.0/. *)
+
+
+
+open Test_helpers
+
+let tests =
+  compile_compare (fun () -> with_bisect ()) "attributes"

--- a/test/unit/test_helpers.ml
+++ b/test/unit/test_helpers.ml
@@ -32,8 +32,18 @@ let _read_file name =
 
 let _command_failed ?status command =
   match status with
-  | None -> Printf.sprintf "'%s' did not exit" command |> failwith
-  | Some v -> Printf.sprintf "'%s' failed with status %i" command v |> failwith
+  | None ->
+    Printf.sprintf "'%s' did not exit" command |> assert_failure
+  | Some v ->
+    let header = Printf.sprintf "'%s' failed with status %i" command v in
+    let full_message =
+      try
+        let output = _read_file "output" in
+        Printf.sprintf "%s\nOutput:\n\n%s" header output
+      with Sys_error _ ->
+        header
+    in
+    assert_failure full_message
 
 let _run_int command =
   begin

--- a/test/unit/test_main.ml
+++ b/test/unit/test_main.ml
@@ -9,6 +9,7 @@ open OUnit2
 let tests = "bisect_ppx" >::: [
   Test_report.tests;
   Test_instrument.tests;
+  Test_attributes.tests;
   Test_warnings.tests;
   Test_line_number_directive.tests;
   Test_comments.tests;


### PR DESCRIPTION
This PR adds three kinds of `[@coverage ...]` attributes:

1. `[@@@coverage off]` and `[@@@coverage on]` for disabling coverage instrumentation inside all expressions in a block of structure items:

    ```ocaml
    [@@@coverage off]

    let foo = ...

    let bar = ...

    [@@@coverage on]
    ```

    @Lupus, in particular, if you surround a type definition that has `[@@deriving sexp]` with these, coverage is suppressed for the generated helpers. At least it was in my testing :)

2. `[@@coverage off]`, which applies to a single binding in a `let`...`and` structure item, and all of its subexpressions:

    ```ocaml
    let foo = ()
      [@@coverage off]
    ```

3. `[@coverage off]`, which applies to an expression and all its subexpressions:

    ```ocaml
    if a then
      f x [@coverage off]
    else
      g y
    ```

Of course, in Reason, they all have the syntax `[@coverage off]`/`[@coverage on]`, with only one `@`, and have to be positioned differently and correctly.

I'll add deprecation warnings to the comments in separate work, and remove them in some future release.

Resolves #196.
Resolves #83.