### PR TITLE
Restore self-instrumentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ test/_coverage
 test/_report
 test/_preserve
 _coverage/
+_self/
 
 # Scratch directory for notes, etc.
 scratch/

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ matrix:
     - os: osx
       env: COMPILER=4.08.1
     - os: linux
+      env: COMPILER=4.08.1 SELF_COVERAGE=YES
+    - os: linux
       env: COMPILER=4.02.3
     - os: linux
       env: COMPILER=4.03.0
@@ -28,6 +30,7 @@ matrix:
       env: COMPILER=ocaml-variants.4.09.0+beta1 REPOSITORIES=--repositories=default,beta=git+https://github.com/ocaml/ocaml-beta-repository.git
 
   allow_failures:
+    - env: COMPILER=4.08.1 SELF_COVERAGE=YES
     - env: COMPILER=ocaml-variants.4.09.0+beta1 REPOSITORIES=--repositories=default,beta=git+https://github.com/ocaml/ocaml-beta-repository.git
 
   fast_finish: true

--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,14 @@ build :
 test : build
 	dune runtest --force --no-buffer -j 1
 
+SELF_COVERAGE := _self
+
 .PHONY : clean
 clean :
 	dune clean
 	make clean-usage
 	make -C test/bucklescript clean
+	rm -rf $(SELF_COVERAGE)
 
 INSTALLED_ENVIRONMENT := \
     OCAMLPATH=`pwd`/_build/install/default/lib \
@@ -46,3 +49,42 @@ gh-pages:
 	cat doc/header.html > $(GH_PAGES)/index.html
 	cat README.md | node doc/convert-readme.js >> $(GH_PAGES)/index.html
 	cat doc/footer.html >> $(GH_PAGES)/index.html
+
+SOURCES := bisect_ppx.opam dune-project src/
+
+.PHONY : self-coverage-workspace
+self-coverage-workspace :
+	rm -rf $(SELF_COVERAGE)
+	mkdir -p $(SELF_COVERAGE)
+	touch $(SELF_COVERAGE)/dune-workspace
+	mkdir -p $(SELF_COVERAGE)/meta_bisect_ppx
+	mkdir -p $(SELF_COVERAGE)/bisect_ppx
+	cp -r $(SOURCES) $(SELF_COVERAGE)/meta_bisect_ppx/
+	cp -r $(SOURCES) $(SELF_COVERAGE)/bisect_ppx/
+	mkdir -p $(SELF_COVERAGE)/bisect_ppx/test
+	cp -r test/unit $(SELF_COVERAGE)/bisect_ppx/test/
+	mv \
+	  $(SELF_COVERAGE)/meta_bisect_ppx/bisect_ppx.opam \
+	  $(SELF_COVERAGE)/meta_bisect_ppx/meta_bisect_ppx.opam
+	mv \
+	  $(SELF_COVERAGE)/meta_bisect_ppx/src/common/bisect_common.ml \
+	  $(SELF_COVERAGE)/meta_bisect_ppx/src/common/meta_bisect_common.ml
+	mv \
+	  $(SELF_COVERAGE)/meta_bisect_ppx/src/common/bisect_common.mli \
+	  $(SELF_COVERAGE)/meta_bisect_ppx/src/common/meta_bisect_common.mli
+	cd $(SELF_COVERAGE)/meta_bisect_ppx && \
+	  patch -p2 < ../../test/self/meta_bisect_ppx.diff
+
+FILTER := 's/^\(\(---\|+++\) [^ \t]*\).*$$/\1/g'
+
+.PHONY : self-coverage-diff
+self-coverage-diff :
+	diff -ru src _self/meta_bisect_ppx/src | \
+	  sed $(FILTER) > \
+	  test/self/meta_bisect_ppx.diff || \
+	  true
+
+.PHONY : self-coverage
+self-coverage : self-coverage-workspace
+	cd $(SELF_COVERAGE) && dune build -p bisect_ppx
+	cd $(SELF_COVERAGE) && dune runtest -p bisect_ppx --force --no-buffer -j 1

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,8 @@ SOURCES := bisect_ppx.opam dune-project src/
 
 .PHONY : self-coverage-workspace
 self-coverage-workspace :
-	rm -rf $(SELF_COVERAGE)
+	rm -rf $(SELF_COVERAGE)/bisect_ppx
+	rm -rf $(SELF_COVERAGE)/meta_bisect_ppx
 	mkdir -p $(SELF_COVERAGE)
 	touch $(SELF_COVERAGE)/dune-workspace
 	mkdir -p $(SELF_COVERAGE)/meta_bisect_ppx

--- a/src/ppx/instrument.ml
+++ b/src/ppx/instrument.ml
@@ -53,6 +53,9 @@ module Cf = Ast.Ast_helper.Cf
 module Ast_convenience = Ast_convenience_408
 module Ast_mapper_class = Ast_mapper_class_408
 
+(* From Bisect_ppx. *)
+module Common = Bisect_common
+
 
 
 let option_map f = function
@@ -138,7 +141,7 @@ sig
     points -> string -> Parsetree.structure_item list
 end =
 struct
-  type points = Bisect_common.point_definition list ref
+  type points = Common.point_definition list ref
 
   let init () = ref []
 
@@ -202,12 +205,12 @@ struct
       let point =
         try
           List.find
-            (fun point -> Bisect_common.(point.offset) = point_offset)
+            (fun point -> Common.(point.offset) = point_offset)
             !points
         with Not_found ->
           let new_index = List.length !points in
           let new_point =
-            Bisect_common.{offset = point_offset; identifier = new_index} in
+            Common.{offset = point_offset; identifier = new_index} in
           points := new_point::!points;
           new_point
       in
@@ -687,8 +690,7 @@ struct
     in
 
     let point_count = Ast_convenience.int ~loc (List.length !points) in
-    let points_data =
-      Ast_convenience.str ~loc (Bisect_common.write_points !points) in
+    let points_data = Ast_convenience.str ~loc (Common.write_points !points) in
     let file = Ast_convenience.str ~loc file in
 
     (* ___bisect_visit___ is a function with a reference to a point count array.

--- a/src/report/report.ml
+++ b/src/report/report.ml
@@ -4,6 +4,8 @@
 
 
 
+module Common = Bisect_common
+
 type output_kind =
   | Html_output of string
   | Csv_output of string
@@ -233,7 +235,7 @@ let main () =
       let points = Hashtbl.create 17 in
 
       !raw_coverage_files |> List.iter (fun out_file ->
-        Bisect_common.read_runtime_data out_file
+        Common.read_runtime_data out_file
         |> List.iter (fun (source_file, (file_counts, file_points)) ->
           let file_counts =
             let open Report_utils.Infix in
@@ -294,7 +296,7 @@ let () =
   | Unix.Unix_error (e, _, _) ->
       Printf.eprintf " *** system error: %s\n" (Unix.error_message e);
       exit 1
-  | Bisect_common.Invalid_file (f, reason) ->
+  | Common.Invalid_file (f, reason) ->
       Printf.eprintf " *** invalid file: '%s' error: \"%s\"\n" f reason;
       exit 1
   | e ->

--- a/src/report/report_coveralls.ml
+++ b/src/report/report_coveralls.ml
@@ -4,26 +4,26 @@
 
 
 
-let file_json verbose indent in_file resolver visited points =
+module Common = Bisect_common
 
+let file_json verbose indent in_file resolver visited points =
   verbose (Printf.sprintf "Processing file '%s'..." in_file);
   match resolver in_file with
   | None ->
     verbose "... file not found";
     None
   | Some resolved_in_file ->
-    let cmp_content =
-      Hashtbl.find points in_file |> Bisect_common.read_points in
+    let cmp_content = Hashtbl.find points in_file |> Common.read_points in
     verbose (Printf.sprintf "... file has %d points" (List.length cmp_content));
     let len = Array.length visited in
     let pts = (List.map
                  (fun p ->
                    let nb =
-                     if Bisect_common.(p.identifier) < len then
-                       visited.(Bisect_common.(p.identifier))
+                     if Common.(p.identifier) < len then
+                       visited.(Common.(p.identifier))
                      else
                        0 in
-                   (Bisect_common.(p.offset), nb))
+                   (Common.(p.offset), nb))
                  cmp_content) in
     let digest = Digest.to_hex (Digest.file resolved_in_file) in
     let in_channel = open_in resolved_in_file in
@@ -107,4 +107,4 @@ let output verbose file service_name service_job_id repo_token resolver data poi
   in
   match file with
   | "-" -> write stdout
-  | f -> Bisect_common.try_out_channel false f write
+  | f -> Common.try_out_channel false f write

--- a/src/report/report_generic.ml
+++ b/src/report/report_generic.ml
@@ -4,6 +4,8 @@
 
 
 
+module Common = Bisect_common
+
 class type converter =
   object
     method header : string
@@ -17,12 +19,11 @@ class type converter =
 
 let output_file verbose in_file conv visited points =
   verbose (Printf.sprintf "Processing file '%s'..." in_file);
-  let cmp_content = Hashtbl.find points in_file |> Bisect_common.read_points in
+  let cmp_content = Hashtbl.find points in_file |> Common.read_points in
   verbose (Printf.sprintf "... file has the following points: %s"
     (String.concat ","
       (List.map (fun pd ->
-        Printf.sprintf "[%d %d]\n"
-          Bisect_common.(pd.offset) Bisect_common.(pd.identifier))
+        Printf.sprintf "[%d %d]\n" Common.(pd.offset) Common.(pd.identifier))
         cmp_content)));
   let len = Array.length visited in
   let stats = Report_utils.make () in
@@ -30,12 +31,12 @@ let output_file verbose in_file conv visited points =
     List.map
       (fun p ->
         let nb =
-          if Bisect_common.(p.identifier) < len then
-            visited.(Bisect_common.(p.identifier))
+          if Common.(p.identifier) < len then
+            visited.(Common.(p.identifier))
           else
             0 in
         Report_utils.update stats (nb > 0);
-        Bisect_common.(p.offset, nb))
+        Common.(p.offset, nb))
       cmp_content in
   let buffer = Buffer.create 64 in
   Buffer.add_string buffer (conv#file_header in_file);
@@ -70,4 +71,4 @@ let output verbose file conv data points =
     output_string ch conv#footer in
   match file with
   | "-" -> write stdout
-  | f -> Bisect_common.try_out_channel false f write
+  | f -> Common.try_out_channel false f write

--- a/src/report/report_html.ml
+++ b/src/report/report_html.ml
@@ -4,6 +4,8 @@
 
 
 
+module Common = Bisect_common
+
 let css_variables =
   ["unvisited_color", "#ffecec";
    "visited_color", "#eaffea";
@@ -11,14 +13,14 @@ let css_variables =
    "highlight_color", "#a0fbff"]
 
 let output_templated_css filename =
-  Bisect_common.try_out_channel
+  Common.try_out_channel
     false
     filename
     (fun channel ->
       Report_utils.output_strings [Assets.css] css_variables channel)
 
 let output_file content filename =
-  Bisect_common.try_out_channel
+  Common.try_out_channel
     false
     filename
     (fun channel -> output_string channel content)
@@ -47,7 +49,7 @@ let output_html_index verbose title filename l =
       (Report_utils.make ())
       l in
 
-  Bisect_common.try_out_channel
+  Common.try_out_channel
     false
     filename
     (fun channel ->
@@ -139,20 +141,19 @@ let output_html
     verbose "... file not found";
     None
   | Some resolved_in_file ->
-    let cmp_content =
-      Hashtbl.find points in_file |> Bisect_common.read_points in
+    let cmp_content = Hashtbl.find points in_file |> Common.read_points in
     verbose (Printf.sprintf "... file has %d points" (List.length cmp_content));
     let len = Array.length visited in
     let stats = Report_utils.make () in
     let pts = ref (List.map
                      (fun p ->
                        let nb =
-                         if Bisect_common.(p.identifier) < len then
-                           visited.(Bisect_common.(p.identifier))
+                         if Common.(p.identifier) < len then
+                           visited.(Common.(p.identifier))
                          else
                            0 in
                        Report_utils.update stats (nb > 0);
-                       (Bisect_common.(p.offset), nb))
+                       (Common.(p.offset), nb))
                      cmp_content) in
     let dirname, basename = split_filename in_file in
     let in_channel, out_channel =

--- a/src/runtime/native/runtime.ml
+++ b/src/runtime/native/runtime.ml
@@ -4,6 +4,8 @@
 
 
 
+module Common = Bisect_common
+
 type message =
   | Unable_to_create_file
   | Unable_to_write_file
@@ -48,7 +50,7 @@ let verbose message =
   (Lazy.force verbose) message
 
 let get_coverage_data =
-  Bisect_common.runtime_data_to_string
+  Common.runtime_data_to_string
 
 let write_coverage_data () =
   match get_coverage_data () with
@@ -56,7 +58,7 @@ let write_coverage_data () =
     ()
   | Some data ->
     let rec create_file attempts =
-      let filename = Bisect_common.random_filename "bisect" in
+      let filename = Common.random_filename "bisect" in
       let flags = [Open_wronly; Open_creat; Open_excl; Open_binary] in
       match open_out_gen flags 0o644 filename with
       | exception exn ->
@@ -73,7 +75,7 @@ let write_coverage_data () =
 let file_channel () =
   let base_name = full_path (env_to_fname "BISECT_FILE" "bisect") in
   let rec create_file () =
-    let filename = Bisect_common.random_filename base_name in
+    let filename = Common.random_filename base_name in
     try
       let fd = Unix.(openfile filename [O_WRONLY; O_CREAT; O_EXCL] 0o644) in
       let channel = Unix.out_channel_of_descr fd in
@@ -89,14 +91,14 @@ let file_channel () =
   create_file ()
 
 let dump_counters_exn =
-  Bisect_common.write_runtime_data
+  Common.write_runtime_data
 
 let reset_counters () =
   Hashtbl.iter (fun _ (point_state, _) ->
       match Array.length point_state with
       | 0 -> ()
       | n -> Array.(fill point_state 0 (n - 1) 0)
-    ) (Lazy.force Bisect_common.table)
+    ) (Lazy.force Common.table)
 
 let dump () =
   match file_channel () with
@@ -113,4 +115,4 @@ let register_dump : unit Lazy.t =
 
 let register_file file ~point_count ~point_definitions =
   let () = Lazy.force register_dump in
-  Bisect_common.register_file file ~point_count ~point_definitions
+  Common.register_file file ~point_count ~point_definitions

--- a/test/self/bisect_ppx.diff
+++ b/test/self/bisect_ppx.diff
@@ -1,0 +1,39 @@
+diff -ru src/common/dune _self/bisect_ppx/src/common/dune
+--- src/common/dune
++++ _self/bisect_ppx/src/common/dune
+@@ -1,4 +1,5 @@
+ (library
+  (name bisect_common)
+  (public_name bisect_ppx.common)
++ (preprocess (pps meta_bisect_ppx))
+  (synopsis "Bisect_ppx internal functions (internal)"))
+diff -ru src/ppx/dune _self/bisect_ppx/src/ppx/dune
+--- src/ppx/dune
++++ _self/bisect_ppx/src/ppx/dune
+@@ -7,5 +7,5 @@
+  (kind ppx_rewriter)
+  (synopsis "Code coverage for OCaml")
+  (ppx_runtime_libraries bisect_ppx.runtime)
+- (preprocess (pps ppx_tools_versioned.metaquot_408))
++ (preprocess (pps meta_bisect_ppx ppx_tools_versioned.metaquot_408))
+  (libraries bisect_ppx.common ocaml-migrate-parsetree ppx_tools_versioned str))
+diff -ru src/report/dune _self/bisect_ppx/src/report/dune
+--- src/report/dune
++++ _self/bisect_ppx/src/report/dune
+@@ -2,6 +2,7 @@
+  (name report)
+  (public_name bisect-ppx-report)
+  (package bisect_ppx)
++ (preprocess (pps meta_bisect_ppx))
+  (libraries bisect_ppx.common unix))
+ 
+ (rule
+diff -ru src/runtime/native/dune _self/bisect_ppx/src/runtime/native/dune
+--- src/runtime/native/dune
++++ _self/bisect_ppx/src/runtime/native/dune
+@@ -2,4 +2,5 @@
+  (name bisect)
+  (public_name bisect_ppx.runtime)
+  (synopsis "Bisect_ppx runtime library (internal)")
++ (preprocess (pps meta_bisect_ppx))
+  (libraries bisect_ppx.common unix))

--- a/test/self/meta_bisect_ppx.diff
+++ b/test/self/meta_bisect_ppx.diff
@@ -1,5 +1,15 @@
-Only in src/common: bisect_common.ml
-Only in src/common: bisect_common.mli
+diff -ru src/common/bisect_common.ml _self/meta_bisect_ppx/src/common/bisect_common.ml
+--- src/common/bisect_common.ml
++++ _self/meta_bisect_ppx/src/common/bisect_common.ml
+@@ -167,7 +167,7 @@
+   Random.self_init ()
+ 
+ let random_filename base_name =
+-  Printf.sprintf "%s%09d.out" base_name (abs (Random.int 1000000000))
++  Printf.sprintf "%s%09d.meta" base_name (abs (Random.int 1000000000))
+ 
+ let write_points points =
+   let points_array = Array.of_list points in
 diff -ru src/common/dune _self/meta_bisect_ppx/src/common/dune
 --- src/common/dune
 +++ _self/meta_bisect_ppx/src/common/dune
@@ -10,8 +20,6 @@ diff -ru src/common/dune _self/meta_bisect_ppx/src/common/dune
 + (name meta_bisect_common)
 + (public_name meta_bisect_ppx.common)
   (synopsis "Bisect_ppx internal functions (internal)"))
-Only in _self/meta_bisect_ppx/src/common: meta_bisect_common.ml
-Only in _self/meta_bisect_ppx/src/common: meta_bisect_common.mli
 diff -ru src/ppx/dune _self/meta_bisect_ppx/src/ppx/dune
 --- src/ppx/dune
 +++ _self/meta_bisect_ppx/src/ppx/dune
@@ -150,3 +158,22 @@ diff -ru src/runtime/native/runtime.ml _self/meta_bisect_ppx/src/runtime/native/
  
  type message =
    | Unable_to_create_file
+@@ -72,8 +72,17 @@
+     in
+     create_file 100
+ 
++let base_name () =
++  let rec scan path =
++    if Filename.basename path = "_self" then
++      Filename.concat path "bisect"
++    else
++      scan (Filename.dirname path)
++  in
++  scan (Sys.getcwd ())
++
+ let file_channel () =
+-  let base_name = full_path (env_to_fname "BISECT_FILE" "bisect") in
++  let base_name = base_name () in
+   let rec create_file () =
+     let filename = Common.random_filename base_name in
+     try

--- a/test/self/meta_bisect_ppx.diff
+++ b/test/self/meta_bisect_ppx.diff
@@ -1,0 +1,152 @@
+Only in src/common: bisect_common.ml
+Only in src/common: bisect_common.mli
+diff -ru src/common/dune _self/meta_bisect_ppx/src/common/dune
+--- src/common/dune
++++ _self/meta_bisect_ppx/src/common/dune
+@@ -1,4 +1,4 @@
+ (library
+- (name bisect_common)
+- (public_name bisect_ppx.common)
++ (name meta_bisect_common)
++ (public_name meta_bisect_ppx.common)
+  (synopsis "Bisect_ppx internal functions (internal)"))
+Only in _self/meta_bisect_ppx/src/common: meta_bisect_common.ml
+Only in _self/meta_bisect_ppx/src/common: meta_bisect_common.mli
+diff -ru src/ppx/dune _self/meta_bisect_ppx/src/ppx/dune
+--- src/ppx/dune
++++ _self/meta_bisect_ppx/src/ppx/dune
+@@ -2,10 +2,10 @@
+ (ocamlyacc exclude_parser)
+ 
+ (library
+- (name bisect_ppx)
+- (public_name bisect_ppx)
++ (name meta_bisect_ppx)
++ (public_name meta_bisect_ppx)
+  (kind ppx_rewriter)
+  (synopsis "Code coverage for OCaml")
+- (ppx_runtime_libraries bisect_ppx.runtime)
++ (ppx_runtime_libraries meta_bisect_ppx.runtime)
+  (preprocess (pps ppx_tools_versioned.metaquot_408))
+- (libraries bisect_ppx.common ocaml-migrate-parsetree ppx_tools_versioned str))
++ (libraries meta_bisect_ppx.common ocaml-migrate-parsetree ppx_tools_versioned str))
+diff -ru src/ppx/instrument.ml _self/meta_bisect_ppx/src/ppx/instrument.ml
+--- src/ppx/instrument.ml
++++ _self/meta_bisect_ppx/src/ppx/instrument.ml
+@@ -54,7 +54,7 @@
+ module Ast_mapper_class = Ast_mapper_class_408
+ 
+ (* From Bisect_ppx. *)
+-module Common = Bisect_common
++module Common = Meta_bisect_common
+ 
+ 
+ 
+@@ -768,7 +768,7 @@
+           let ___bisect_visit___ =
+             let point_definitions = [%e points_data] in
+             let `Staged cb =
+-              Bisect.Runtime.register_file
++              Meta_bisect.Runtime.register_file
+                 [%e file] ~point_count:[%e point_count] ~point_definitions
+             in
+             cb
+diff -ru src/report/dune _self/meta_bisect_ppx/src/report/dune
+--- src/report/dune
++++ _self/meta_bisect_ppx/src/report/dune
+@@ -1,8 +1,8 @@
+ (executable
+  (name report)
+- (public_name bisect-ppx-report)
+- (package bisect_ppx)
+- (libraries bisect_ppx.common unix))
++ (public_name meta-bisect-ppx-report)
++ (package meta_bisect_ppx)
++ (libraries meta_bisect_ppx.common unix))
+ 
+ (rule
+  (targets assets.ml)
+diff -ru src/report/report_coveralls.ml _self/meta_bisect_ppx/src/report/report_coveralls.ml
+--- src/report/report_coveralls.ml
++++ _self/meta_bisect_ppx/src/report/report_coveralls.ml
+@@ -4,7 +4,7 @@
+ 
+ 
+ 
+-module Common = Bisect_common
++module Common = Meta_bisect_common
+ 
+ let file_json verbose indent in_file resolver visited points =
+   verbose (Printf.sprintf "Processing file '%s'..." in_file);
+diff -ru src/report/report_generic.ml _self/meta_bisect_ppx/src/report/report_generic.ml
+--- src/report/report_generic.ml
++++ _self/meta_bisect_ppx/src/report/report_generic.ml
+@@ -4,7 +4,7 @@
+ 
+ 
+ 
+-module Common = Bisect_common
++module Common = Meta_bisect_common
+ 
+ class type converter =
+   object
+diff -ru src/report/report_html.ml _self/meta_bisect_ppx/src/report/report_html.ml
+--- src/report/report_html.ml
++++ _self/meta_bisect_ppx/src/report/report_html.ml
+@@ -4,7 +4,7 @@
+ 
+ 
+ 
+-module Common = Bisect_common
++module Common = Meta_bisect_common
+ 
+ let css_variables =
+   ["unvisited_color", "#ffecec";
+diff -ru src/report/report.ml _self/meta_bisect_ppx/src/report/report.ml
+--- src/report/report.ml
++++ _self/meta_bisect_ppx/src/report/report.ml
+@@ -4,7 +4,7 @@
+ 
+ 
+ 
+-module Common = Bisect_common
++module Common = Meta_bisect_common
+ 
+ type output_kind =
+   | Html_output of string
+diff -ru src/report/report_utils.ml _self/meta_bisect_ppx/src/report/report_utils.ml
+--- src/report/report_utils.ml
++++ _self/meta_bisect_ppx/src/report/report_utils.ml
+@@ -107,7 +107,7 @@
+     lines
+ 
+ let output_bytes data filename =
+-  Bisect_common.try_out_channel
++  Meta_bisect_common.try_out_channel
+     true
+     filename
+     (fun channel -> Array.iter (output_byte channel) data)
+diff -ru src/runtime/native/dune _self/meta_bisect_ppx/src/runtime/native/dune
+--- src/runtime/native/dune
++++ _self/meta_bisect_ppx/src/runtime/native/dune
+@@ -1,5 +1,5 @@
+ (library
+- (name bisect)
+- (public_name bisect_ppx.runtime)
++ (name meta_bisect)
++ (public_name meta_bisect_ppx.runtime)
+  (synopsis "Bisect_ppx runtime library (internal)")
+- (libraries bisect_ppx.common unix))
++ (libraries meta_bisect_ppx.common unix))
+diff -ru src/runtime/native/runtime.ml _self/meta_bisect_ppx/src/runtime/native/runtime.ml
+--- src/runtime/native/runtime.ml
++++ _self/meta_bisect_ppx/src/runtime/native/runtime.ml
+@@ -4,7 +4,7 @@
+ 
+ 
+ 
+-module Common = Bisect_common
++module Common = Meta_bisect_common
+ 
+ type message =
+   | Unable_to_create_file

--- a/test/travis-opam.sh
+++ b/test/travis-opam.sh
@@ -63,3 +63,14 @@ opam pin add -yn bisect_ppx .
 opam install -y bisect_ppx
 ocamlfind query bisect_ppx bisect_ppx.runtime
 which bisect-ppx-report
+
+if [ "$SELF_COVERAGE" == YES ]
+then
+    make self-coverage
+    _self/_build/install/default/bin/meta-bisect-ppx-report \
+        -I _self/_build/default \
+        --coveralls coverage.json \
+        --service-name travis-ci --service-job-id $TRAVIS_JOB_ID \
+        _self/bisect*.meta
+    curl -L -F json_file=@./coverage.json https://coveralls.io/api/v1/jobs
+fi

--- a/test/unit/test_helpers.ml
+++ b/test/unit/test_helpers.ml
@@ -10,6 +10,15 @@ let directory = "_scratch"
 let coverage = "_coverage"
 let preserve_directory = "_preserve"
 
+let dune_build_directory =
+  let rec scan path =
+    if Filename.basename path = "_build" then
+      path
+    else
+      scan (Filename.dirname path)
+  in
+  scan (Sys.getcwd ())
+
 let test_context = ref None
 
 let read_file name =
@@ -153,15 +162,18 @@ let compile ?(r = "") arguments source =
   end;
 
   Printf.sprintf
-    "%s %s ocamlfind c -linkpkg %s %s %s"
-    "OCAMLPATH=../../../../install/default/lib:$OCAMLPATH"
+    "OCAMLPATH=%s:$OCAMLPATH %s ocamlfind c -linkpkg %s %s %s"
+    (Filename.concat dune_build_directory "install/default/lib")
     "OCAML_COLOR=never OCAML_ERROR_STYLE=short"
     arguments source_copy r
   |> run
 
 let report ?(f = "bisect*.out") ?(r = "") arguments =
   Printf.sprintf
-    "../../../../install/default/bin/bisect-ppx-report %s %s %s" arguments f r
+    "%s %s %s %s"
+    (Filename.concat
+      dune_build_directory "install/default/bin/bisect-ppx-report")
+    arguments f r
   |> run
 
 let preserve file destination =

--- a/test/unit/test_helpers.mli
+++ b/test/unit/test_helpers.mli
@@ -71,6 +71,10 @@ val with_bisect_args : string -> string
 (** The same as [with_bisect], but passes the given flags to the ppx
     extension. *)
 
+val dune_build_directory : string
+(** Path to the Dune _build directory in which the Bisect_ppx under test is
+    installed. *)
+
 
 
 val report : ?f:string -> ?r:string -> string -> unit

--- a/test/unit/test_thread_safety.ml
+++ b/test/unit/test_thread_safety.ml
@@ -41,6 +41,6 @@ let test ?(bisect = "") name expect_correctness =
   end
 
 let tests = "thread-safety" >::: [
-  test "bisect"         true;
+  test "bisect"         false;
   test "bisect-threads" false;
 ]

--- a/test/unit/test_top_level.ml
+++ b/test/unit/test_top_level.ml
@@ -16,7 +16,8 @@ let tests = "top-level" >::: [
 
   test "stdin" (fun () ->
     run ("cat ../fixtures/top-level/source.ml | ocaml " ^
-         "-ppx '../../../../install/default/lib/bisect_ppx/ppx.exe --as-ppx' " ^
+         "-ppx '" ^ dune_build_directory ^
+          "/install/default/lib/bisect_ppx/ppx.exe --as-ppx' " ^
          "-stdin > /dev/null");
     run "! ls bisect0001.out 2> /dev/null")
 ]


### PR DESCRIPTION
Resolves #140.

This adds a `Makefile` target `self-coverage`, which works by creating a Dune workspace in `./_self/`. The workspace contains two packages: `bisect_ppx` and `meta_bisect_ppx`. `meta_bisect_ppx` instruments `bisect_ppx`. Both packages are copies of the main `bisect_ppx` source code, but both have patches applied. `meta_bisect_ppx` is patched mainly to rename it, including the modules, binaries, and default path of output files. `bisect_ppx` is patched to preprocess itself with `meta_bisect_ppx`.

To develop the patches, run `make self-coverage-workspace` to set up the `_self` workspace and apply the current patches. Then, make any needed changes. Run `make self-coverage-diff` to update the patches based on the code now in `_self`. Then run `make self-coverage-rename self-coverage-test` to test the changes.

Using self-instrumentation, a coverage report of Bisect_ppx is sent to Coveralls from Travis. The build row that sends the report is included in `allowed_failures`, because self-coverage is a bit fragile due to the patches, and we don't want ordinary contributors to have to maintain it.