### PR TITLE
Reporter: don't require -I _build/default for Dune

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,6 @@ self-coverage-test :
 	rm -rf _coverage
 	cd $(SELF_COVERAGE) && \
 	  _build/install/default/bin/meta-bisect-ppx-report \
-	    -I _build/default \
 	    --text - --summary-only \
 	    --html ../_coverage \
 	    bisect*.meta

--- a/Makefile
+++ b/Makefile
@@ -103,9 +103,10 @@ self-coverage-test :
 	cd $(SELF_COVERAGE) && dune build
 	cd $(SELF_COVERAGE) && dune runtest --force --no-buffer -j 1
 	rm -rf _coverage
-	$(SELF_COVERAGE)/_build/install/default/bin/meta-bisect-ppx-report \
-	  -I $(SELF_COVERAGE)/_build/default \
-	  --text - --summary-only \
-	  --html _coverage \
-	  $(SELF_COVERAGE)/bisect*.meta
+	cd $(SELF_COVERAGE) && \
+	  _build/install/default/bin/meta-bisect-ppx-report \
+	    -I _build/default \
+	    --text - --summary-only \
+	    --html ../_coverage \
+	    bisect*.meta
 	@echo See _coverage/index.html

--- a/src/report/report.ml
+++ b/src/report/report.ml
@@ -26,7 +26,7 @@ let report_title = ref "Coverage report"
 
 let csv_separator = ref ";"
 
-let search_path = ref [""]
+let search_path = ref ["_build/default"; ""]
 
 let add_search_path sp =
   search_path := sp :: !search_path

--- a/test/travis-opam.sh
+++ b/test/travis-opam.sh
@@ -67,10 +67,11 @@ which bisect-ppx-report
 if [ "$SELF_COVERAGE" == YES ]
 then
     make self-coverage
-    _self/_build/install/default/bin/meta-bisect-ppx-report \
-        -I _self/_build/default \
-        --coveralls coverage.json \
-        --service-name travis-ci --service-job-id $TRAVIS_JOB_ID \
-        _self/bisect*.meta
+    (cd _self && \
+        _build/install/default/bin/meta-bisect-ppx-report \
+            -I _build/default \
+            --coveralls ../coverage.json \
+            --service-name travis-ci --service-job-id $TRAVIS_JOB_ID \
+            bisect*.meta)
     curl -L -F json_file=@./coverage.json https://coveralls.io/api/v1/jobs
 fi

--- a/test/travis-opam.sh
+++ b/test/travis-opam.sh
@@ -69,7 +69,6 @@ then
     make self-coverage
     (cd _self && \
         _build/install/default/bin/meta-bisect-ppx-report \
-            -I _build/default \
             --coveralls ../coverage.json \
             --service-name travis-ci --service-job-id $TRAVIS_JOB_ID \
             bisect*.meta)

--- a/test/usage/reason/Makefile
+++ b/test/usage/reason/Makefile
@@ -6,8 +6,7 @@ test : clean
 	BISECT_ENABLE=YES dune exec ./source.exe
 	ls -l _build
 	test -f bisect*.out
-	bisect-ppx-report \
-	  -I _build/default/ --html _coverage/ `find . -name 'bisect*.out'`
+	bisect-ppx-report --html _coverage/ `find . -name 'bisect*.out'`
 
 .PHONY : clean
 clean :


### PR DESCRIPTION
This simplifies the command line for a very common case, and simplifies all our instructions.

`_build/default` is now in the default search paths of the reporter.

Part of #203.