### PR TITLE
Reporter: implement --send-to

### DIFF
--- a/src/report/report.ml
+++ b/src/report/report.ml
@@ -21,6 +21,7 @@ sig
   val service_name : string ref
   val service_job_id : string ref
   val repo_token : string ref
+  val send_to : string option ref
 
   val parse_args : unit -> unit
   val print_usage : unit -> unit
@@ -60,6 +61,8 @@ struct
   let service_job_id = ref ""
 
   let repo_token = ref ""
+
+  let send_to = ref None
 
   let options = [
     ("--html",
@@ -130,6 +133,10 @@ struct
     ("--repo-token",
     Arg.Set_string repo_token,
     "<string>  Repo token for Coveralls json (Coveralls only)");
+
+    ("--send-to",
+    Arg.String (fun s -> send_to := Some s),
+    "<string>  Coveralls or Codecov")
 ]
 
   let deprecated = Common.deprecated
@@ -194,9 +201,9 @@ let warning =
   Printf.ksprintf (fun s ->
     Printf.eprintf "Warning: %s\n%!" s)
 
-let error =
+let error arguments =
   Printf.ksprintf (fun s ->
-    Printf.eprintf "Error: %s\n%!" s; exit 1)
+    Printf.eprintf "Error: %s\n%!" s; exit 1) arguments
 
 
 
@@ -296,16 +303,131 @@ end
 
 
 
+type ci = [
+  | `CircleCI
+  | `Travis
+]
+
+module CI :
+sig
+  val detect : unit -> ci option
+  val pretty_name : ci -> string
+  val name_in_report : ci -> string
+  val job_id_variable : ci -> string
+end =
+struct
+  let environment_variable name value result k =
+    match Sys.getenv name with
+    | value' when value' = value -> Some result
+    | _ -> k ()
+    | exception Not_found -> k ()
+
+  let detect () =
+    environment_variable "CIRCLECI" "true" `CircleCI @@ fun () ->
+    environment_variable "TRAVIS" "true" `Travis @@ fun () ->
+    None
+
+  let pretty_name = function
+    | `CircleCI -> "CircleCI"
+    | `Travis -> "Travis"
+
+  let name_in_report = function
+    | `CircleCI -> "circleci"
+    | `Travis -> "travis-ci"
+
+  let job_id_variable = function
+    | `CircleCI -> "CIRCLE_BUILD_NUM"
+    | `Travis -> "TRAVIS_JOB_ID"
+end
+
+
+
+type coverage_service = [
+  | `Codecov
+  | `Coveralls
+]
+
+module Coverage_service :
+sig
+  val from_argument : unit -> coverage_service option
+  val pretty_name : coverage_service -> string
+  val report_filename : coverage_service -> string
+  val send_command : coverage_service -> string
+end =
+struct
+  let from_argument () =
+    match !Arguments.send_to with
+    | None -> None
+    | Some "Codecov" -> Some `Codecov
+    | Some "Coveralls" -> Some `Coveralls
+    | Some other -> error "--send-to: unknown coverage service '%s'" other
+
+  let pretty_name = function
+    | `Codecov -> "Codecov"
+    | `Coveralls -> "Coveralls"
+
+  let report_filename = function
+    | `Codecov -> "excoveralls.json"
+    | `Coveralls -> "coverage.json"
+
+  let send_command = function
+    | `Codecov ->
+      "bash <(curl -s https://codecov.io/bash)"
+    | `Coveralls ->
+      "curl -L -F json_file=@./coverage.json https://coveralls.io/api/v1/jobs"
+end
+
+
+
 open Arguments
 
 let main () =
   parse_args ();
-  if !report_outputs = [] then begin
+  if !report_outputs = [] && !Arguments.send_to = None then begin
     print_usage ();
     exit 0
   end;
 
   quiet := Arguments.is_report_being_written_to_stdout ();
+
+  let coverage_service = Coverage_service.from_argument () in
+
+  begin match coverage_service with
+  | None ->
+    ()
+  | Some service ->
+    let report_file = Coverage_service.report_filename service in
+    info "writing coverage report to '%s'" report_file;
+    Arguments.report_outputs :=
+      !Arguments.report_outputs @ [`Coveralls, report_file];
+
+    let ci =
+      lazy begin
+        match CI.detect () with
+        | Some ci ->
+          info "detected CI: %s" (CI.pretty_name ci);
+          ci
+        | None ->
+          error "unknown CI service or not in CI"
+      end
+    in
+
+    if !Arguments.service_name = "" then begin
+      let service_name = CI.name_in_report (Lazy.force ci) in
+      info "using service_name '%s'" service_name;
+      Arguments.service_name := service_name;
+    end;
+
+    if !Arguments.service_job_id = "" then begin
+      let job_id_variable = CI.job_id_variable (Lazy.force ci) in
+      info "using service_job_id variable $%s" job_id_variable;
+      match Sys.getenv job_id_variable with
+      | value ->
+        Arguments.service_job_id := value
+      | exception Not_found ->
+        error "expected job id in $%s" job_id_variable
+    end
+  end;
 
   let data, points =
       let total_counts = Hashtbl.create 17 in
@@ -360,12 +482,21 @@ let main () =
         Report_coveralls.output verbose file
           !service_name !service_job_id !repo_token
           search_in_path data points in
-  List.iter write_output (List.rev !report_outputs)
+  List.iter write_output (List.rev !report_outputs);
+
+  match coverage_service with
+  | None ->
+    ()
+  | Some coverage_service ->
+    let name = Coverage_service.pretty_name coverage_service in
+    let command = Coverage_service.send_command coverage_service in
+    info "sending to %s with command:" name;
+    info " %s" command;
+    Sys.command command |> exit
 
 let () =
   try
-    main ();
-    exit 0
+    main ()
   with
   | Sys_error s ->
       Printf.eprintf " *** system error: %s\n" s;

--- a/test/ci/travis-opam.sh
+++ b/test/ci/travis-opam.sh
@@ -86,10 +86,7 @@ then
     make self-coverage
     (cd _self && \
         _build/install/default/bin/meta-bisect-ppx-report \
-            --coveralls ../coverage.json \
-            --service-name travis-ci --service-job-id $TRAVIS_JOB_ID \
-            bisect*.meta)
-    curl -L -F json_file=@./coverage.json https://coveralls.io/api/v1/jobs
+            bisect*.meta --send-to Coveralls)
 fi
 
 opam clean


### PR DESCRIPTION
Usage is `bisect-ppx-report --send-to Coveralls`.

The command automatically takes care of everything:

- Detecting the CI (resolves #228).
- Generating the coverage report.
- Uploading the report to the coverage service (resolves #233).

In the future, it will also need to try to retrieve the repo token (#239) and read git info (#217).

The tests for this will probably be in [bisect-ci-integrations-megatest](https://github.com/aantron/bisect-ci-integration-megatest) (#227). Perhaps I'll add a `--dry-run` option for testing this offline.