### PR TITLE
Coveralls format: support git info

### DIFF
--- a/src/report/report.ml
+++ b/src/report/report.ml
@@ -21,6 +21,7 @@ sig
   val service_name : string ref
   val service_job_id : string ref
   val repo_token : string ref
+  val git : bool ref
   val send_to : string option ref
 
   val parse_args : unit -> unit
@@ -61,6 +62,8 @@ struct
   let service_job_id = ref ""
 
   let repo_token = ref ""
+
+  let git = ref false
 
   let send_to = ref None
 
@@ -133,6 +136,10 @@ struct
     ("--repo-token",
     Arg.Set_string repo_token,
     "<string>  Repo token for Coveralls json (Coveralls only)");
+
+    ("--git",
+    Arg.Set git,
+    " Parse git HEAD info (Coveralls only)");
 
     ("--send-to",
     Arg.String (fun s -> send_to := Some s),
@@ -514,7 +521,7 @@ let main () =
         generic_output file (Report_dump.make ())
     | `Coveralls, file ->
         Report_coveralls.output verbose file
-          !service_name !service_job_id !repo_token
+          !service_name !service_job_id !repo_token !Arguments.git
           search_in_path data points in
   List.iter write_output (List.rev !report_outputs);
 

--- a/src/report/report_coveralls.mli
+++ b/src/report/report_coveralls.mli
@@ -8,8 +8,11 @@
 
 
 val output :
-  (string -> unit) -> string -> string -> string -> string -> (string -> string option) ->
-  (string, int array) Hashtbl.t -> (string, string) Hashtbl.t ->
+  (string -> unit) ->
+  string -> string -> string -> string -> bool ->
+  (string -> string option) ->
+  (string, int array) Hashtbl.t ->
+  (string, string) Hashtbl.t ->
     unit
 (** [output verbose file service_name service_job_id repo_token resolver data points]
     writes a Coveralls JSON [file] for [data]. [verbose] is used for verbose

--- a/test/unit/fixtures/report/coveralls_reference.json
+++ b/test/unit/fixtures/report/coveralls_reference.json
@@ -1,6 +1,7 @@
 {
     "service_name": "travis-ci",
     "service_job_id": "123",
+
     "source_files": [
         {
             "name": "source.ml",


### PR DESCRIPTION
Adds reporter `--git` option for including git revision info in the Coveralls report. This is included automatically when using `--send-to Coveralls` from CircleCI.

Resolves #217.