### PR TITLE
Return the AST directly when bisect is disabled

### DIFF
--- a/src/ppx/register.ml
+++ b/src/ppx/register.ml
@@ -89,8 +89,7 @@ let () =
     match enabled () with
       | `Enabled ->
         new Instrument.instrumenter#transform_impl_file ctxt ast
-      | `Disabled ->
-        new Ppxlib.Ast_traverse.map_with_expansion_context#structure ctxt ast
+      | `Disabled -> ast
   in
   let instrument = Ppxlib.Driver.Instrument.V2.make impl ~position:After in
   Ppxlib.Driver.register_transformation ~instrument "bisect_ppx"


### PR DESCRIPTION
It is more efficient to directly return the AST instead of recursing through it without modifying it. I introduced that inefficiency in the port to ppxlib and would like to fix it with this PR. 