### PR TITLE
Report: merge coverage files

### DIFF
--- a/src/common/bisect_common.ml
+++ b/src/common/bisect_common.ml
@@ -64,8 +64,11 @@ let register_file ~filename ~points =
     if current_count < max_int then
       counts.(index) <- current_count + 1)
 
+let flatten_coverage coverage =
+  Hashtbl.fold (fun _ file acc -> file::acc) coverage []
+
 let flatten_data () =
-  Hashtbl.fold (fun _ file acc -> file::acc) (Lazy.force coverage) []
+  flatten_coverage (Lazy.force coverage)
 
 let reset_counters () =
   Lazy.force coverage
@@ -87,6 +90,9 @@ let runtime_data_to_string () =
     let buffer = Buffer.create 4096 in
     write_coverage (Format.formatter_of_buffer buffer) data;
     Some (Buffer.contents buffer)
+
+let write_runtime_coverage coverage channel =
+  write_coverage (Format.formatter_of_out_channel channel) (flatten_coverage coverage)
 
 let write_runtime_data channel =
   write_coverage (Format.formatter_of_out_channel channel) (flatten_data ())

--- a/src/common/bisect_common.mli
+++ b/src/common/bisect_common.mli
@@ -65,6 +65,9 @@ val register_file :
 
 (** {1 [.coverage] output} *)
 
+val write_runtime_coverage : coverage -> out_channel -> unit
+(** Writes the [coverage] to the given output channel. *)
+
 val write_runtime_data : out_channel -> unit
 (** Writes the current accumulated coverage data (of type {!coverage}) to the
     given output channel. *)

--- a/src/report/main.ml
+++ b/src/report/main.ml
@@ -256,6 +256,16 @@ let coveralls =
 
 
 
+let merge =
+  let call_with_labels
+      to_file coverage_files coverage_paths expect do_not_expect =
+    Merge.output
+      ~to_file ~coverage_files ~coverage_paths ~expect ~do_not_expect
+  in
+  Term.(const set_verbose $ verbose $ const call_with_labels $ to_file
+    $ coverage_files 1 $ coverage_paths $ expect $ do_not_expect),
+  term_info "merge" ~doc:"Merge coverage files"
+
 (* Entry point. *)
 
 let () =
@@ -273,5 +283,5 @@ let () =
           ("See bisect-ppx-report $(i,COMMAND) --help for further " ^
           "information on each command, including options.")
       ]))
-    [html; send_to; text; cobertura; coveralls]
+    [html; send_to; text; cobertura; coveralls; merge]
   |> Term.exit

--- a/src/report/main.ml
+++ b/src/report/main.ml
@@ -257,13 +257,11 @@ let coveralls =
 
 
 let merge =
-  let call_with_labels
-      to_file coverage_files coverage_paths expect do_not_expect =
-    Merge.output
-      ~to_file ~coverage_files ~coverage_paths ~expect ~do_not_expect
+  let call_with_labels to_file coverage_files coverage_paths =
+    Merge.output ~to_file ~coverage_files ~coverage_paths
   in
   Term.(const set_verbose $ verbose $ const call_with_labels $ to_file
-    $ coverage_files 1 $ coverage_paths $ expect $ do_not_expect),
+    $ coverage_files 1 $ coverage_paths),
   term_info "merge" ~doc:"Merge coverage files"
 
 (* Entry point. *)

--- a/src/report/merge.ml
+++ b/src/report/merge.ml
@@ -3,10 +3,10 @@
    https://github.com/aantron/bisect_ppx/blob/master/LICENSE.md. *)
 
 
-let output ~to_file ~coverage_files ~coverage_paths ~expect ~do_not_expect =
+let output ~to_file ~coverage_files ~coverage_paths =
   let coverage =
     Input.load_coverage
-      ~coverage_files ~coverage_paths ~expect ~do_not_expect in
+      ~coverage_files ~coverage_paths ~expect:[] ~do_not_expect:[] in
   let () = Util.mkdirs (Filename.dirname to_file) in
   let oc = open_out to_file in
   try

--- a/src/report/merge.ml
+++ b/src/report/merge.ml
@@ -1,0 +1,17 @@
+(* This file is part of Bisect_ppx, released under the MIT license. See
+   LICENSE.md for details, or visit
+   https://github.com/aantron/bisect_ppx/blob/master/LICENSE.md. *)
+
+
+let output ~to_file ~coverage_files ~coverage_paths ~expect ~do_not_expect =
+  let coverage =
+    Input.load_coverage
+      ~coverage_files ~coverage_paths ~expect ~do_not_expect in
+  let () = Util.mkdirs (Filename.dirname to_file) in
+  let oc = open_out to_file in
+  try
+    let () = Bisect_common.write_runtime_coverage coverage oc in
+    close_out oc
+  with exn ->
+    close_out_noerr oc;
+    raise exn

--- a/src/report/merge.mli
+++ b/src/report/merge.mli
@@ -8,9 +8,9 @@
 
 
 val output :
-     to_file:string
-  -> coverage_files:string list
-  -> coverage_paths:string list
-  -> expect:string list
-  -> do_not_expect:string list
-  -> unit
+  to_file:string ->
+  coverage_files:string list ->
+  coverage_paths:string list ->
+  expect:string list ->
+  do_not_expect:string list ->
+    unit

--- a/src/report/merge.mli
+++ b/src/report/merge.mli
@@ -4,7 +4,7 @@
 
 
 
-(** This module merge the existing coverage files into a single coverage file *)
+(** This module merges coverage files into a single coverage file, summing counters pointwise *)
 
 
 val output :

--- a/src/report/merge.mli
+++ b/src/report/merge.mli
@@ -11,6 +11,4 @@ val output :
   to_file:string ->
   coverage_files:string list ->
   coverage_paths:string list ->
-  expect:string list ->
-  do_not_expect:string list ->
     unit

--- a/src/report/merge.mli
+++ b/src/report/merge.mli
@@ -1,0 +1,16 @@
+(* This file is part of Bisect_ppx, released under the MIT license. See
+   LICENSE.md for details, or visit
+   https://github.com/aantron/bisect_ppx/blob/master/LICENSE.md. *)
+
+
+
+(** This module merge the existing coverage files into a single coverage file *)
+
+
+val output :
+     to_file:string
+  -> coverage_files:string list
+  -> coverage_paths:string list
+  -> expect:string list
+  -> do_not_expect:string list
+  -> unit

--- a/test/report/dune
+++ b/test/report/dune
@@ -1,3 +1,3 @@
 (cram
- (deps test.ml)
+ (deps test.ml merge.ml test_merge1.ml test_merge2.ml)
  (alias compatible))

--- a/test/report/merge.ml
+++ b/test/report/merge.ml
@@ -1,0 +1,8 @@
+let rec sum = function
+  | [] -> 0
+  | x :: xs -> x + sum xs
+
+let rec product = function
+  | [] -> 1
+  | x :: xs -> x * product xs
+

--- a/test/report/merge.t
+++ b/test/report/merge.t
@@ -1,0 +1,13 @@
+Merge two files
+
+  $ echo "(lang dune 2.7)" > dune-project
+  $ cat > dune <<'EOF'
+  > (executables
+  >  (names test_merge1 test_merge2)
+  >  (instrumentation (backend bisect_ppx)))
+  > EOF
+  $ dune exec ./test_merge1.exe --instrument-with bisect_ppx
+  $ dune exec ./test_merge2.exe --instrument-with bisect_ppx
+  $ bisect-ppx-report merge merged.coverage
+  $ cat merged.coverage
+  BISECT-COVERAGE-4 3 8 merge.ml 6 56 27 39 126 93 105 6 0 1 0 0 1 0 14 test_merge1.ml 2 27 18 2 1 1 14 test_merge2.ml 2 31 18 2 1 1

--- a/test/report/merge.t
+++ b/test/report/merge.t
@@ -7,7 +7,20 @@ Merge two files
   >  (instrumentation (backend bisect_ppx)))
   > EOF
   $ dune exec ./test_merge1.exe --instrument-with bisect_ppx
+  $ bisect-ppx-report summary --per-file
+   16.67 %   1/6   merge.ml
+  100.00 %   2/2   test_merge1.ml
+   37.50 %   3/8   Project coverage
   $ dune exec ./test_merge2.exe --instrument-with bisect_ppx
-  $ bisect-ppx-report merge merged.coverage
-  $ cat merged.coverage
-  BISECT-COVERAGE-4 3 8 merge.ml 6 56 27 39 126 93 105 6 0 1 0 0 1 0 14 test_merge1.ml 2 27 18 2 1 1 14 test_merge2.ml 2 31 18 2 1 1
+  $ bisect-ppx-report summary --per-file
+   33.33 %   2/6    merge.ml
+  100.00 %   2/2    test_merge1.ml
+  100.00 %   2/2    test_merge2.ml
+   60.00 %   6/10   Project coverage
+  $ bisect-ppx-report merge merged.temp
+  $ rm -rf _build; rm *.coverage; mv merged.temp merged.coverage
+  $ bisect-ppx-report summary --per-file
+   33.33 %   2/6    merge.ml
+  100.00 %   2/2    test_merge1.ml
+  100.00 %   2/2    test_merge2.ml
+   60.00 %   6/10   Project coverage

--- a/test/report/test_merge1.ml
+++ b/test/report/test_merge1.ml
@@ -1,0 +1,1 @@
+let () = assert (Merge.sum [] = 0)

--- a/test/report/test_merge2.ml
+++ b/test/report/test_merge2.ml
@@ -1,0 +1,1 @@
+let () = assert (Merge.product [] = 1)


### PR DESCRIPTION
Close #388 

I started doing merge by hand but `Input.load_coverage` already does the merge between coverage files.

(I created a dedicated switch, it should not have compatibility issues.)