### PR TITLE
Points in an array instead of list

### DIFF
--- a/src/common/bisect_common.ml
+++ b/src/common/bisect_common.ml
@@ -9,7 +9,7 @@
 
 type instrumented_file = {
   filename : string;
-  points : int list;
+  points : int array;
   counts : int array;
 }
 
@@ -37,7 +37,7 @@ let write_list write_element formatter l =
 
 let write_instrumented_file formatter {filename; points; counts} =
   write_string formatter filename;
-  write_list write_int formatter points;
+  write_list write_int formatter (Array.to_list points);
   write_array write_int formatter counts
 
 let write_coverage formatter coverage =
@@ -55,7 +55,7 @@ let coverage : coverage Lazy.t =
   lazy (Hashtbl.create 17)
 
 let register_file ~filename ~points =
-  let counts = Array.make (List.length points) 0 in
+  let counts = Array.make (Array.length points) 0 in
   let coverage = Lazy.force coverage in
   if not (Hashtbl.mem coverage filename) then
     Hashtbl.add coverage filename {filename; points; counts};

--- a/src/common/bisect_common.ml
+++ b/src/common/bisect_common.ml
@@ -37,7 +37,7 @@ let write_list write_element formatter l =
 
 let write_instrumented_file formatter {filename; points; counts} =
   write_string formatter filename;
-  write_list write_int formatter (Array.to_list points);
+  write_array write_int formatter points;
   write_array write_int formatter counts
 
 let write_coverage formatter coverage =

--- a/src/common/bisect_common.mli
+++ b/src/common/bisect_common.mli
@@ -25,7 +25,7 @@
 
 type instrumented_file = {
   filename : string; (** Source file name. *)
-  points : int list; (** Byte offsets of the points placed in the file. *)
+  points : int array; (** Byte offsets of the points placed in the file. *)
   counts : int array; (** Visitation counts, one for each point. *)
 }
 (** Data gathered for a single source file. *)
@@ -45,7 +45,7 @@ val coverage_file_identifier : string
 (** {1 Initialization} *)
 
 val register_file :
-  filename:string -> points:int list -> [`Visit of (int -> unit)]
+  filename:string -> points:int array -> [`Visit of (int -> unit)]
 (** Each source file is instrumented to call {!Bisect.Runtime.register_file} at
     run time, during program initialization. {!Bisect.Runtime.register_file}
     eventually forwards to this function, {!Biesct_common.register_file}. This

--- a/src/ppx/instrument.ml
+++ b/src/ppx/instrument.ml
@@ -891,7 +891,7 @@ struct
 
     let points_data =
         Ast_builder.Default.pexp_array ~loc (List.map (
-          fun offset -> Ast_builder.Default.eint ~loc: Location.none offset
+          fun offset -> Ast_builder.Default.eint ~loc offset
         ) (List.rev points.offsets))
     in
     let filename = Ast_builder.Default.estring ~loc file in

--- a/src/ppx/instrument.ml
+++ b/src/ppx/instrument.ml
@@ -890,9 +890,10 @@ struct
     in
 
     let points_data =
-        Ast_builder.Default.pexp_array ~loc (List.map (
-          fun offset -> Ast_builder.Default.eint ~loc offset
-        ) (List.rev points.offsets))
+      Ast_builder.Default.pexp_array ~loc
+        (List.map
+          (fun offset -> Ast_builder.Default.eint ~loc offset)
+          (List.rev points.offsets))
     in
     let filename = Ast_builder.Default.estring ~loc file in
 

--- a/src/ppx/instrument.ml
+++ b/src/ppx/instrument.ml
@@ -890,15 +890,9 @@ struct
     in
 
     let points_data =
-      let open Parsetree in
-        let rec inline_point_offsets acc = function
-        | [] -> acc
-        | offset::more ->
-          inline_point_offsets
-            [%expr [%e Ast_builder.Default.eint ~loc offset]::[%e acc]]
-            more
-      in
-      inline_point_offsets [%expr []] points.offsets
+        Ast_builder.Default.pexp_array ~loc (List.map (
+          fun offset -> Ast_builder.Default.eint ~loc: Location.none offset
+        ) (List.rev points.offsets))
     in
     let filename = Ast_builder.Default.estring ~loc file in
 

--- a/src/report/html.ml
+++ b/src/report/html.ml
@@ -151,6 +151,7 @@ let output_for_source_file
   let stats = ref (0, 0) in
   let points =
     points
+    |> Array.to_list
     |> List.mapi (fun index offset -> (offset, index))
     |> List.sort compare
   in

--- a/src/report/input.ml
+++ b/src/report/input.ml
@@ -187,7 +187,7 @@ let read_list read_element buffer channel =
 
 let read_instrumented_file buffer channel =
   let filename = read_string buffer channel |> get_relative_path in
-  let points = read_list read_int buffer channel in
+  let points = read_array read_int buffer channel in
   let counts = read_array read_int buffer channel in
   Bisect_common.{filename; points; counts}
 

--- a/src/report/util.ml
+++ b/src/report/util.ml
@@ -104,6 +104,7 @@ let line_counts ~filename ~points ~counts =
   let len = Array.length counts in
   let points =
     points
+    |> Array.to_list
     |> List.mapi (fun index offset -> (offset, index))
     |> List.sort compare
   in

--- a/src/report/util.mli
+++ b/src/report/util.mli
@@ -64,7 +64,7 @@ val find_source_file :
 (** {1 Coverage statistics} *)
 
 val line_counts :
-  filename:string -> points:int list -> counts:int array -> int option list
+  filename:string -> points:int array -> counts:int array -> int option list
 (** Computes the visited lines for [~filename]. For each line, returns either:
 
     - [None], if there is no point on the line.

--- a/src/runtime/js/runtime.mli
+++ b/src/runtime/js/runtime.mli
@@ -9,7 +9,7 @@ val register_file :
   bisect_silent:string option ->
   bisect_sigterm:bool ->
   filename:string ->
-  points:int list ->
+  points:int array ->
     [`Visit of (int -> unit)]
 (** [register_file file ~bisect_file ~bisect_silent ~point_count
     ~point_definitions] indicates that the file [file] is part of the

--- a/src/runtime/native/runtime.mli
+++ b/src/runtime/native/runtime.mli
@@ -47,7 +47,7 @@ val register_file :
   bisect_silent:string option ->
   bisect_sigterm:bool ->
   filename:string ->
-  points:int list ->
+  points:int array ->
     [`Visit of (int -> unit)]
 (** [register_file ~bisect_file ~bisect_silent ~bisect_sigterm file ~point_count
     ~point_definitions] indicates that the file [file] is part of the

--- a/test/instrument/recent/exclusions.t
+++ b/test/instrument/recent/exclusions.t
@@ -39,7 +39,7 @@
   module Bisect_visit___not_excluded___ml =
     struct
       let ___bisect_visit___ =
-        let points = [12] in
+        let points = [|12|] in
         let `Visit visit =
           Bisect.Runtime.register_file ~bisect_file:None ~bisect_silent:None
             ~filename:"not_excluded.ml" ~points ~bisect_sigterm:false in

--- a/test/instrument/structure.t
+++ b/test/instrument/structure.t
@@ -5,7 +5,7 @@ An empty file. Show the bare registration code.
   > EOF
   module Bisect_visit___test___ml = struct
     let ___bisect_visit___ =
-      let points = [] in
+      let points = [||] in
       let (`Visit visit) =
         Bisect.Runtime.register_file ~bisect_file:None ~bisect_silent:None
           ~filename:"test.ml" ~points ~bisect_sigterm:false


### PR DESCRIPTION
In ReScript lists are compiled as a nested data structure, resulting in a very deep data structure. In large files this causes babel to stack overflow. With this change, the points are saved as an array, which is represented as a simple JavaScript array.