### PR TITLE
Ppxlib.0.26.0 compatibility

### DIFF
--- a/bisect_ppx.opam
+++ b/bisect_ppx.opam
@@ -22,7 +22,7 @@ depends: [
   "cmdliner" {>= "1.0.0"}
   "dune" {>= "2.7.0"}
   "ocaml" {>= "4.03.0"}
-  "ppxlib" {>= "0.21.0"}
+  "ppxlib" {>= "0.26.0"}
 
   "ocamlformat" {with-test & = "0.16.0"}
 ]

--- a/bisect_ppx.opam
+++ b/bisect_ppx.opam
@@ -19,7 +19,7 @@ maintainer: [
 
 depends: [
   "base-unix"
-  "cmdliner" {>= "1.0.0" & < "1.1.0"}
+  "cmdliner" {>= "1.0.0"}
   "dune" {>= "2.7.0"}
   "ocaml" {>= "4.03.0"}
   "ppxlib" {>= "0.26.0"}

--- a/bisect_ppx.opam
+++ b/bisect_ppx.opam
@@ -19,7 +19,7 @@ maintainer: [
 
 depends: [
   "base-unix"
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "1.1.0"}
   "dune" {>= "2.7.0"}
   "ocaml" {>= "4.03.0"}
   "ppxlib" {>= "0.26.0"}

--- a/bisect_ppx.opam
+++ b/bisect_ppx.opam
@@ -22,7 +22,7 @@ depends: [
   "cmdliner" {>= "1.0.0"}
   "dune" {>= "2.7.0"}
   "ocaml" {>= "4.03.0"}
-  "ppxlib" {>= "0.26.0"}
+  "ppxlib" {>= "0.26.0" & < "0.29.0"}
 
   "ocamlformat" {with-test & = "0.16.0"}
 ]

--- a/src/ppx/instrument.ml
+++ b/src/ppx/instrument.ml
@@ -490,10 +490,13 @@ struct
         |> List.map (fun (location_trace, p'') ->
           (location_trace, Pat.alias ~loc ~attrs p'' x))
 
-      | Ppat_construct (c, Some p') ->
+      | Ppat_construct (c, Some ([], p')) ->
         recur ~enclosing_loc p'
         |> List.map (fun (location_trace, p'') ->
           (location_trace, Pat.construct ~loc ~attrs c (Some p'')))
+
+      | Ppat_construct (_, Some (_ :: _, _)) ->
+        Location.raise_errorf ~loc "bisect_ppx: named existentials aren't supported"
 
       | Ppat_variant (c, Some p') ->
         recur ~enclosing_loc p'
@@ -708,10 +711,13 @@ struct
       List.map (fun (_, p') -> bound_variables p') fields
       |> List.flatten
 
-    | Ppat_construct (_, Some p') | Ppat_variant (_, Some p')
+    | Ppat_construct (_, Some ([], p')) | Ppat_variant (_, Some p')
     | Ppat_constraint (p', _) | Ppat_lazy p' | Ppat_exception p'
     | Ppat_open (_, p') ->
       bound_variables p'
+
+    | Ppat_construct (_, Some ({loc; _} :: _, _)) ->
+      Location.raise_errorf ~loc "bisect_ppx: named existentials aren't supported"
 
     | Ppat_or (p_1, _) ->
       bound_variables p_1 (* Should be unreachable. *)
@@ -725,10 +731,13 @@ struct
     | Ppat_type _ | Ppat_variant _ ->
       true
 
-    | Ppat_alias (p', _) | Ppat_construct (_, Some p')
+    | Ppat_alias (p', _) | Ppat_construct (_, Some ([], p'))
     | Ppat_constraint (p', _) | Ppat_lazy p' | Ppat_exception p'
     | Ppat_open (_, p') ->
       has_polymorphic_variant p'
+
+    | Ppat_construct (_, Some ({loc; _} :: _, _)) ->
+      Location.raise_errorf ~loc "bisect_ppx: named existentials aren't supported"
 
     | Ppat_tuple ps | Ppat_array ps ->
       List.exists has_polymorphic_variant ps

--- a/src/ppx/instrument.ml
+++ b/src/ppx/instrument.ml
@@ -490,13 +490,10 @@ struct
         |> List.map (fun (location_trace, p'') ->
           (location_trace, Pat.alias ~loc ~attrs p'' x))
 
-      | Ppat_construct (c, Some ([], p')) ->
+      | Ppat_construct (c, Some (exnames, p')) ->
         recur ~enclosing_loc p'
         |> List.map (fun (location_trace, p'') ->
-          (location_trace, Pat.construct ~loc ~attrs c (Some p'')))
-
-      | Ppat_construct (_, Some (_ :: _, _)) ->
-        Location.raise_errorf ~loc "bisect_ppx: named existentials aren't supported"
+          (location_trace, Pat.mk  ~loc ~attrs Pat.(Ppat_construct (c, Some(exnames, p'')))))
 
       | Ppat_variant (c, Some p') ->
         recur ~enclosing_loc p'
@@ -711,13 +708,10 @@ struct
       List.map (fun (_, p') -> bound_variables p') fields
       |> List.flatten
 
-    | Ppat_construct (_, Some ([], p')) | Ppat_variant (_, Some p')
+    | Ppat_construct (_, Some (_, p')) | Ppat_variant (_, Some p')
     | Ppat_constraint (p', _) | Ppat_lazy p' | Ppat_exception p'
     | Ppat_open (_, p') ->
       bound_variables p'
-
-    | Ppat_construct (_, Some ({loc; _} :: _, _)) ->
-      Location.raise_errorf ~loc "bisect_ppx: named existentials aren't supported"
 
     | Ppat_or (p_1, _) ->
       bound_variables p_1 (* Should be unreachable. *)
@@ -731,13 +725,10 @@ struct
     | Ppat_type _ | Ppat_variant _ ->
       true
 
-    | Ppat_alias (p', _) | Ppat_construct (_, Some ([], p'))
+    | Ppat_alias (p', _) | Ppat_construct (_, Some (_, p'))
     | Ppat_constraint (p', _) | Ppat_lazy p' | Ppat_exception p'
     | Ppat_open (_, p') ->
       has_polymorphic_variant p'
-
-    | Ppat_construct (_, Some ({loc; _} :: _, _)) ->
-      Location.raise_errorf ~loc "bisect_ppx: named existentials aren't supported"
 
     | Ppat_tuple ps | Ppat_array ps ->
       List.exists has_polymorphic_variant ps


### PR DESCRIPTION
This is a patch PR to make the PPX compatible with ppxlib.0.26.0 which has bumped the AST to 4.14/5.00.