### PR TITLE
Respect [@coverage off] for or-patterns

### DIFF
--- a/src/ppx/instrument.ml
+++ b/src/ppx/instrument.ml
@@ -854,27 +854,28 @@ struct
           if case_should_not_be_instrumented case then
             case::exception_cases
           else
-          let case =
-            match rotate_or_patterns_to_top loc p with
-            | [] ->
-              insert_instrumentation points
-                case
-                (fun e -> instrument_expr points e)
-            | [(location_trace, _)] ->
-              insert_instrumentation points
-                case
-                (instrumentation_for_location_trace points location_trace)
-            | rotated_cases ->
-              let nested_match =
-                rotated_cases
-                |> List.map (fun (trace, p) -> trace, drop_exception_patterns p)
-                |> generate_nested_match points loc
-              in
-              insert_instrumentation points
-                {case with pc_lhs = alias_exceptions loc p}
-                (fun e -> [%expr [%e nested_match]; [%e e]])
-          in
-          case::exception_cases
+            let case =
+              match rotate_or_patterns_to_top loc p with
+              | [] ->
+                insert_instrumentation points
+                  case
+                  (fun e -> instrument_expr points e)
+              | [(location_trace, _)] ->
+                insert_instrumentation points
+                  case
+                  (instrumentation_for_location_trace points location_trace)
+              | rotated_cases ->
+                let nested_match =
+                  rotated_cases
+                  |> List.map (fun (trace, p) ->
+                    trace, drop_exception_patterns p)
+                  |> generate_nested_match points loc
+                in
+                insert_instrumentation points
+                  {case with pc_lhs = alias_exceptions loc p}
+                  (fun e -> [%expr [%e nested_match]; [%e e]])
+            in
+            case::exception_cases
       in
 
       value_cases, exception_cases, functions, need_binding, index + 1

--- a/test/instrument/attribute.t
+++ b/test/instrument/attribute.t
@@ -80,3 +80,30 @@ Non-coverage attributes are preserved uninstrumented.
   let _ = () [@@foo print_endline "bar"]
   
   let _ = () [@foo print_endline "bar"]
+
+
+Or-pattern coverage is suppressed for cases with [@coverage off].
+
+  $ bash test.sh <<'EOF'
+  > let () =
+  >   match `A with
+  >   | `A | `B -> () [@coverage off]
+  >   | `C | `D -> ()
+  >   | exception Not_found | exception Exit -> () [@coverage off]
+  > EOF
+  let () =
+    match `A with
+    | (exception Not_found) | (exception Exit) -> () [@coverage off]
+    | `A | `B -> () [@coverage off]
+    | (`C | `D) as ___bisect_matched_value___ ->
+        (match[@ocaml.warning "-4-8-9-11-26-27-28-33"]
+           ___bisect_matched_value___
+         with
+        | `C ->
+            ___bisect_visit___ 0;
+            ()
+        | `D ->
+            ___bisect_visit___ 1;
+            ()
+        | _ -> ());
+        ()

--- a/test/instrument/recent/refutation.t
+++ b/test/instrument/recent/refutation.t
@@ -48,3 +48,21 @@ instrumented.
         | _ -> ());
         ()
     | `C | `D -> assert false
+
+
+assert false exception cases don't get instrumented.
+
+  $ bash ../test.sh <<'EOF'
+  > let _ =
+  >   match `A with
+  >   | `A -> ()
+  >   | exception Not_found -> assert false
+  >   | exception Invalid_argument _ | exception Exit -> assert false
+  > EOF
+  let _ =
+    match `A with
+    | exception Not_found -> assert false
+    | (exception Invalid_argument _) | (exception Exit) -> assert false
+    | `A ->
+        ___bisect_visit___ 0;
+        ()


### PR DESCRIPTION
Fixes #414.

As a side-effect, we also don't instrument exception cases with `assert false` anymore, which was arguably another bug.

cc @nlsandler

I'm going to hold off merging this PR because I want to do some things to the CI first and do a release to npm, but I will merge it right after. You can use this immediately using

```
opam pin add bisect_ppx 'git+https://github.com/aantron/bisect_ppx.git#or-coverage-off'
```

...or otherwise getting the `or-coverage-off` branch.