### PR TITLE
Add <packages> to cobertura format

### DIFF
--- a/test/report/cobertura.t
+++ b/test/report/cobertura.t
@@ -13,18 +13,20 @@
     <sources>
       <source>.</source>
     </sources>
-    <package name="." line-rate="0.333333">
-      <classes>
-        <class name="test.ml" filename="test.ml" line-rate="0.333333">
-          <lines>
-            <line number="2" hits="1"/>
-            <line number="5" hits="0"/>
-            <line number="8" hits="1"/>
-            <line number="13" hits="0"/>
-            <line number="14" hits="0"/>
-            <line number="16" hits="0"/>
-          </lines>
-        </class>
-      </classes>
-    </package>
+    <packages>
+      <package name="." line-rate="0.333333">
+        <classes>
+          <class name="test.ml" filename="test.ml" line-rate="0.333333">
+            <lines>
+              <line number="2" hits="1"/>
+              <line number="5" hits="0"/>
+              <line number="8" hits="1"/>
+              <line number="13" hits="0"/>
+              <line number="14" hits="0"/>
+              <line number="16" hits="0"/>
+            </lines>
+          </class>
+        </classes>
+      </package>
+    </packages>
   </coverage>


### PR DESCRIPTION
This PR adds `<packages>` to cobertura format.

[Issue](https://github.com/aantron/bisect_ppx/issues/416)