### PR TITLE
Adapt to ReScript 11

### DIFF
--- a/src/common/bisect_common.ml
+++ b/src/common/bisect_common.ml
@@ -80,12 +80,12 @@ let register_file ~filename ~points =
 
 
 let reset_counters () =
-  Lazy.force coverage
-  |> Hashtbl.iter begin fun _ {counts; _} ->
+  Hashtbl.iter begin fun _ {counts; _} ->
     match Array.length counts with
     | 0 -> ()
     | n -> Array.fill counts 0 (n - 1) 0
   end
+    (Lazy.force coverage)
 
 
 

--- a/src/runtime/js/runtime.ml
+++ b/src/runtime/js/runtime.ml
@@ -4,6 +4,48 @@
 
 
 
+(* Code based on Melange, inherited from BuckleScript:
+
+   https://github.com/melange-re/melange/blob/da421be55e755096403425ed3c260486deab61f3/jscomp/others/node_fs.ml *)
+module Node =
+struct
+  module Fs =
+  struct
+    external openSync :
+      string ->
+      ([ `Read [@as "r"]
+      | `Read_write [@as "r+"]
+      | `Read_write_sync [@as "rs+"]
+      | `Write [@as "w"]
+      | `Write_fail_if_exists [@as "wx"]
+      | `Write_read [@as "w+"]
+      | `Write_read_fail_if_exists [@as "wx+"]
+      | `Append [@as "a"]
+      | `Append_fail_if_exists [@as "ax"]
+      | `Append_read [@as "a+"]
+      | `Append_read_fail_if_exists [@as "ax+"] ]
+      [@string]) ->
+      unit = "openSync"
+      [@@module "fs"]
+
+    type encoding = [
+      | `hex
+      | `utf8
+      | `ascii
+      | `latin1
+      | `base64
+      | `ucs2
+      | `base64
+      | `binary
+      | `utf16le
+    ]
+
+    external writeFileSync : string -> string -> encoding -> unit =
+      "writeFileSync"
+      [@@val] [@@module "fs"]
+  end
+end
+
 let get_coverage_data =
   Bisect_common.runtime_data_to_string
 

--- a/test/js/package.json
+++ b/test/js/package.json
@@ -2,7 +2,7 @@
   "name": "bisect_ppx-test",
   "dependencies": {
     "bisect_ppx": "file:package",
-    "rescript": "11.0.0-beta.2",
+    "rescript": "^10",
     "esy": "^0.6.7"
   },
   "scripts": {

--- a/test/js/package.json
+++ b/test/js/package.json
@@ -2,7 +2,7 @@
   "name": "bisect_ppx-test",
   "dependencies": {
     "bisect_ppx": "file:package",
-    "rescript": "^10",
+    "rescript": "11.0.0-beta.2",
     "esy": "^0.6.7"
   },
   "scripts": {


### PR DESCRIPTION
There is still an issue remaining:

> Thanks for the heads up! I've fixed some incompatibilities in [9439ba7](https://github.com/aantron/bisect_ppx/commit/9439ba71f1c138ca38229affa180ffef6aa3b978), but I'm currently left with:
> 
> ```
> λ make -C test/js full-test
> 
> [...]
> 
> > node ./lib/js/hello.js
> 
> internal/modules/cjs/loader.js:818
>   throw err;
>   ^
> 
> Error: Cannot find module '/home/antron/code/bisect/bisect_ppx/test/js/lib/js/hello.js'
>     at Function.Module._resolveFilename (internal/modules/cjs/loader.js:815:15)
>     at Function.Module._load (internal/modules/cjs/loader.js:667:27)
>     at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:60:12)
>     at internal/main/run_main_module.js:17:47 {
>   code: 'MODULE_NOT_FOUND',
>   requireStack: []
> }
> ```
> 
> This is the former location of the output, `hello.js`, with ReScript <= 10. As far as I can tell, there is no output file at all now:
> 
> ```
> λ cd test/js && find lib                                                                                                                                          2
> 
> lib
> lib/bs
> lib/bs/.bsdeps
> lib/bs/.bsbuild
> lib/bs/.compiler.log
> lib/bs/build.ninja
> lib/bs/.ninja_log
> lib/bs/install.ninja
> lib/bs/.sourcedirs.json
> lib/js
> ```
> 
> Could you suggest what changed in ReScript 11? I wasn't able to spot a relevant change in the changelogs for the ReScript 11 pre-release versions.

This appears to be a silent compilation error.

cc @cristianoc