### PR TITLE
Add `--sort-by-stats` flag to html reporter

### DIFF
--- a/src/report/html.ml
+++ b/src/report/html.ml
@@ -56,9 +56,10 @@ end = struct
 
   let rec flatten files =
     files
-    |> List.concat_map (function
+    |> List.map (function
       | (File _) as f -> [ f ]
       | Directory (_, files, _) -> flatten files)
+    |> List.concat
 end
 
 let output_html_index ~tree ~sort_by_stats title theme filename files =

--- a/src/report/html.ml
+++ b/src/report/html.ml
@@ -31,15 +31,12 @@ type index_element =
   | File of index_file
   | Directory of (string * index_element list * (int * int))
 
-module Index_element : sig
-  type t = index_element
-
-  val sort_by_stats : t list -> t list
-
-  val flatten : t list -> t list
-end = struct
-  type t = index_element
-
+module Index_element :
+sig
+  val sort_by_stats : index_element list -> index_element list
+  val flatten : index_element list -> index_element list
+end =
+struct
   let percentage = function
     | File (_, _, stat) -> percentage stat
     | Directory (_, _, stat) -> percentage stat
@@ -51,13 +48,14 @@ end = struct
     files
     |> List.map (function
       | (File _) as f -> f
-      | Directory (name, files, stats) -> Directory (name, sort_by_stats files, stats))
+      | Directory (name, files, stats) ->
+        Directory (name, sort_by_stats files, stats))
     |> List.sort compare_by_stat
 
   let rec flatten files =
     files
     |> List.map (function
-      | (File _) as f -> [ f ]
+      | (File _) as f -> [f]
       | Directory (_, files, _) -> flatten files)
     |> List.concat
 end
@@ -171,8 +169,9 @@ let output_html_index ~tree ~sort_by_stats title theme filename files =
 
     let files =
       match sort_by_stats, tree with
-      | false, (false|true) -> files
-      | true, false -> files |> Index_element.flatten |> Index_element.sort_by_stats
+      | false, _ -> files
+      | true, false ->
+        files |> Index_element.flatten |> Index_element.sort_by_stats
       | true, true -> files |> Index_element.sort_by_stats
     in
 
@@ -539,7 +538,8 @@ let output_string_to_separate_file content filename =
 
 let output
     ~to_directory ~title ~tab_size ~theme ~coverage_files ~coverage_paths
-    ~source_paths ~ignore_missing_files ~expect ~do_not_expect ~tree ~sort_by_stats =
+    ~source_paths ~ignore_missing_files ~expect ~do_not_expect ~tree
+    ~sort_by_stats =
 
   (* Read all the [.coverage] files and get per-source file visit counts. *)
   let coverage =

--- a/src/report/html.mli
+++ b/src/report/html.mli
@@ -16,4 +16,5 @@ val output :
   expect:string list ->
   do_not_expect:string list ->
   tree:bool ->
+  sort_by_stats:bool ->
     unit

--- a/src/report/main.ml
+++ b/src/report/main.ml
@@ -179,17 +179,23 @@ let html =
       info ["tree"] ~doc:
         ("Generate collapsible directory tree with per-directory summaries."))
   in
+  let sort_by_stats =
+    Arg.(value @@ flag @@
+      info ["sort-by-stats"] ~doc:
+        ("Sort reported files by increasing values of coverage stats."))
+  in
 
   let call_with_labels
       to_directory title tab_size theme coverage_files coverage_paths
-      source_paths ignore_missing_files expect do_not_expect tree =
+      source_paths ignore_missing_files expect do_not_expect tree sort_by_stats =
     Html.output
       ~to_directory ~title ~tab_size ~theme ~coverage_files ~coverage_paths
-      ~source_paths ~ignore_missing_files ~expect ~do_not_expect ~tree
+      ~source_paths ~ignore_missing_files ~expect ~do_not_expect ~tree ~sort_by_stats
   in
   Term.(const set_verbose $ verbose $ const call_with_labels $ to_directory
     $ title $ tab_size $ theme $ coverage_files 0 $ coverage_paths
-    $ source_paths $ ignore_missing_files $ expect $ do_not_expect $ tree),
+    $ source_paths $ ignore_missing_files $ expect $ do_not_expect $ tree
+    $ sort_by_stats),
   term_info "html" ~doc:"Generate HTML report locally."
     ~man:[
       `S "USAGE EXAMPLE";

--- a/src/report/main.ml
+++ b/src/report/main.ml
@@ -182,15 +182,17 @@ let html =
   let sort_by_stats =
     Arg.(value @@ flag @@
       info ["sort-by-stats"] ~doc:
-        ("Sort reported files by increasing values of coverage stats."))
+        ("Sort files in order of increasing coverage stats."))
   in
 
   let call_with_labels
       to_directory title tab_size theme coverage_files coverage_paths
-      source_paths ignore_missing_files expect do_not_expect tree sort_by_stats =
+      source_paths ignore_missing_files expect do_not_expect tree
+      sort_by_stats =
     Html.output
       ~to_directory ~title ~tab_size ~theme ~coverage_files ~coverage_paths
-      ~source_paths ~ignore_missing_files ~expect ~do_not_expect ~tree ~sort_by_stats
+      ~source_paths ~ignore_missing_files ~expect ~do_not_expect ~tree
+      ~sort_by_stats
   in
   Term.(const set_verbose $ verbose $ const call_with_labels $ to_directory
     $ title $ tab_size $ theme $ coverage_files 0 $ coverage_paths


### PR DESCRIPTION
In this pull request, I have added a `--sort-by-stats` flag to the html-report
command. This flag provides an option for users to order the files in the index
page of the report by their coverage statistics in ascending order.

I have also ensured that this new flag works in conjunction with the existing
`--tree` option : when both `--sort-by-stats` and `--tree` flags are used, the
directories, as well as the files within each directory, are sorted by coverage
statistics.

This addition is intended to offer a different perspective for developers who
are working on improving coverage in existing codebases. By presenting files
with lower coverage at the top, this option could potentially assist in
prioritizing areas that may benefit from additional testing.

### Note on Code Formatting

I encountered some difficulties to `fmt` the code due to issues finding a
compatible combination of dependencies with opam. Despite trying several OCaml
switches ranging from 4.05 to 5.1, I was unsuccessful. The `ocamlformat.0.16.0`
version seems to be outdated. Any assistance in resolving this issue would be
greatly appreciated!

Looking forward to your feedback!