### PR TITLE
Update ocamlformat version

### DIFF
--- a/bisect_ppx.opam
+++ b/bisect_ppx.opam
@@ -25,7 +25,7 @@ depends: [
   "ppxlib" {>= "0.28.0"}
 
   "dune" {with-test & >= "3.0.0"}
-  "ocamlformat" {with-test & = "0.16.0"}
+  "ocamlformat" {with-test & = "0.27.0"}
 ]
 
 build: [


### PR DESCRIPTION
This fixes a problem where the project cannot be solved when `with-test` is true. It depended on ocamlformat.0.16.0 which in turn depends on ppxlib < 0.22, but this project also depends on ppxlib >= 0.28.0, so no solution was possible.

I came across this problem when trying to solve the project's dependencies with dune package management, which becomes possible after this change.